### PR TITLE
Add the check-upstream.sh script

### DIFF
--- a/check-upstream.sh
+++ b/check-upstream.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+OVERLAYS_REPO=${1:-overlays}
+
+PACKAGES=(`opam list --repo="$OVERLAYS_REPO" -A -s`)
+
+if [[ ${#PACKAGES[@]} -eq 0 ]]; then
+	echo "No package found for repository $OVERLAYS_REPO"
+	exit 2
+fi
+
+STATUS=0
+
+for pkg in `opam show -f package "${PACKAGES[@]}"`; do
+	if ! [[ $pkg = *"+dune" ]]; then
+		echo "New version upstream: $pkg"
+		STATUS=1
+	fi
+done
+
+exit $STATUS


### PR DESCRIPTION
Checks if there is a new upstream version for each overlay packages.

The current output:
```
New version upstream: extlib.1.7.6
New version upstream: fmt.0.8.6
New version upstream: psq.0.1.1
New version upstream: tls.0.10.2
New version upstream: uuidm.0.9.7
```

The script requires an opam installation with the default and the overlays repositories up to date.
It takes the name of the overlays repository as argument.