### PR TITLE
Release fmt.0.8.6 dune port

### DIFF
--- a/packages/fmt/fmt.0.8.6+dune/opam
+++ b/packages/fmt/fmt.0.8.6+dune/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: [ "The fmt programmers" ]
+homepage: "https://erratique.ch/software/fmt"
+doc: "https://erratique.ch/software/fmt"
+dev-repo: "git+https://github.com/dune-universe/fmt.git"
+bug-reports: "https://github.com/dbuenzli/fmt/issues"
+tags: [ "string" "format" "pretty-print" "org:erratique" ]
+license: "ISC"
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+run-test: [
+  [ "dune" "runtest" "-p" name "-j" jobs ]
+]
+depends: [
+  "dune" {build}
+  "ocaml" {>= "4.03.0"}
+  # Can be removed once ocaml >= 4.07
+  "seq"
+  "stdlib-shims"
+]
+depopts: [ "base-unix" "cmdliner" ]
+conflicts: [ "cmdliner" {< "0.9.8"} ]
+url: {
+  src: "git+https://github.com/dune-universe/fmt#v0.8.6+dune 
+}


### PR DESCRIPTION
I just pushed the port [here](https://github.com/dune-universe/fmt/commit/0522ff405f207af1f79bda66700546bf468ef236).

The previous port used jbuilder so I updated it a bit and removed `topkg` files to keep things clean.

I didn't actually handle the depopts which makes me wonder about how `duniverse` currently handle those. I'm guessing it won't pull them in, meaning the project won't build so I might need to fix that before we merge this PR.