### PR TITLE
Fix set dune overlay url as dev-repo

### DIFF
--- a/packages/asetmap/asetmap.0.8.1+dune/opam
+++ b/packages/asetmap/asetmap.0.8.1+dune/opam
@@ -4,7 +4,7 @@ authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
 homepage: "http://erratique.ch/software/asetmap"
 doc: "http://erratique.ch/software/asetmap/doc"
 license: "ISC"
-dev-repo: "git+http://erratique.ch/repos/asetmap.git"
+dev-repo: "git+https://github.com/dune-universe/asetmap.git"
 bug-reports: "https://github.com/dbuenzli/asetmap/issues"
 tags: [ "org:erratique" "set" "map" "stdlib" ]
 depends: [

--- a/packages/asn1-combinators/asn1-combinators.0.2.0+dune/opam
+++ b/packages/asn1-combinators/asn1-combinators.0.2.0+dune/opam
@@ -4,7 +4,7 @@ maintainer: "David Kaloper Meršinjak <david@numm.org>"
 homepage: "https://github.com/mirleft/ocaml-asn1-combinators"
 doc: "https://mirleft.github.io/ocaml-asn1-combinators/doc"
 license: "ISC"
-dev-repo: "git+https://github.com/mirleft/ocaml-asn1-combinators.git"
+dev-repo: "git+https://github.com/dune-universe/ocaml-asn1-combinators.git"
 bug-reports: "https://github.com/mirleft/ocaml-asn1-combinators/issues"
 tags: [ "org:mirage" ]
 depends: [

--- a/packages/astring/astring.0.8.3+dune/opam
+++ b/packages/astring/astring.0.8.3+dune/opam
@@ -3,7 +3,7 @@ maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
 authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
 homepage: "http://erratique.ch/software/astring"
 doc: "http://erratique.ch/software/astring/doc"
-dev-repo: "git+http://erratique.ch/repos/astring.git"
+dev-repo: "git+https://github.com/dune-universe/astring.git"
 bug-reports: "https://github.com/dbuenzli/astring/issues"
 tags: [ "string" "org:erratique" ]
 license: "ISC"

--- a/packages/bos/bos.0.2.0+dune/opam
+++ b/packages/bos/bos.0.2.0+dune/opam
@@ -3,7 +3,7 @@ maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
 authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
 homepage: "http://erratique.ch/software/bos"
 doc: "http://erratique.ch/software/bos/doc"
-dev-repo: "git+http://erratique.ch/repos/bos.git"
+dev-repo: "git+https://github.com/dune-universe/bos.git"
 bug-reports: "https://github.com/dbuenzli/bos/issues"
 tags: [ "os" "system" "cli" "command" "file" "path" "log" "unix" "org:erratique" ]
 license: "ISC"

--- a/packages/cmdliner/cmdliner.1.0.2+dune/opam
+++ b/packages/cmdliner/cmdliner.1.0.2+dune/opam
@@ -3,7 +3,7 @@ maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
 authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
 homepage: "http://erratique.ch/software/cmdliner"
 doc: "http://erratique.ch/software/cmdliner/doc/Cmdliner"
-dev-repo: "git+http://erratique.ch/repos/cmdliner.git"
+dev-repo: "git+https://github.com/dune-universe/cmdliner.git"
 bug-reports: "https://github.com/dbuenzli/cmdliner/issues"
 tags: [ "cli" "system" "declarative" "org:erratique" ]
 license: "ISC"

--- a/packages/cmdliner/cmdliner.1.0.3+dune/opam
+++ b/packages/cmdliner/cmdliner.1.0.3+dune/opam
@@ -3,7 +3,7 @@ maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
 authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
 homepage: "http://erratique.ch/software/cmdliner"
 doc: "http://erratique.ch/software/cmdliner/doc/Cmdliner"
-dev-repo: "git+http://erratique.ch/repos/cmdliner.git"
+dev-repo: "git+https://github.com/dune-universe/cmdliner.git"
 bug-reports: "https://github.com/dbuenzli/cmdliner/issues"
 tags: [ "cli" "system" "declarative" "org:erratique" ]
 license: "ISC"

--- a/packages/cudf/cudf.0.9+dune/opam
+++ b/packages/cudf/cudf.0.9+dune/opam
@@ -3,7 +3,7 @@ maintainer: "roberto@dicosmo.org"
 authors: ["Roberto di Cosmo <roberto@dicosmo.org>" "Stefano Zacchiroli" "Pietro Abate"]
 homepage: "http://www.mancoosi.org/cudf/"
 bug-reports: "https://gforge.inria.fr/tracker/?atid=13811&group_id=4385&func=browse"
-dev-repo: "git+https://scm.gforge.inria.fr/anonscm/git/cudf/cudf.git"
+dev-repo: "git+https://github.com/dune-universe/cudf.git"
 depends: [
   "dune" {build}
   "ocaml"

--- a/packages/dispatch/dispatch.0.4.0+dune/opam
+++ b/packages/dispatch/dispatch.0.4.0+dune/opam
@@ -3,7 +3,7 @@ maintainer: "Spiros Eliopoulos <spiros@inhabitedtype.com>"
 authors: [ "Spiros Eliopoulos <spiros@inhabitedtype.com>" ]
 license: "BSD-3-clause"
 homepage: "https://github.com/inhabitedtype/ocaml-dispatch"
-dev-repo: "git+https://github.com/inhabitedtype/ocaml-dispatch.git"
+dev-repo: "git+https://github.com/dune-universe/ocaml-dispatch.git"
 bug-reports: "https://github.com/inhabitedtype/ocaml-dispatch/issues"
 depends: [
   "dune" {build}

--- a/packages/dose3/dose3.5.0.1+dune/opam
+++ b/packages/dose3/dose3.5.0.1+dune/opam
@@ -13,7 +13,7 @@ authors: [
 homepage: "http://www.mancoosi.org/software/"
 bug-reports: "https://gforge.inria.fr/tracker/?group_id=4395"
 license: "LGPL-v3+ with OCaml linking exception"
-dev-repo: "git+https://gforge.inria.fr/git/dose/dose.git"
+dev-repo: "git+https://github.com/dune-universe/dose3.git"
 depends: [
   "dune" {build}
   "ocaml"

--- a/packages/extlib/extlib.1.7.4+dune/opam
+++ b/packages/extlib/extlib.1.7.4+dune/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 maintainer: "ygrek@autistici.org"
 homepage: "https://github.com/ygrek/ocaml-extlib"
-dev-repo: "git://github.com/ygrek/ocaml-extlib.git"
+dev-repo: "git+https://github.com/dune-universe/ocaml-extlib.git"
 bug-reports: "https://github.com/ygrek/ocaml-extlib/issues"
 doc: ["http://ygrek.org.ua/p/extlib/doc/"]
 license: "LGPL-2.1 with OCaml linking exception"

--- a/packages/extlib/extlib.1.7.5+dune/opam
+++ b/packages/extlib/extlib.1.7.5+dune/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 maintainer: "ygrek@autistici.org"
 homepage: "https://github.com/ygrek/ocaml-extlib"
-dev-repo: "git://github.com/ygrek/ocaml-extlib.git"
+dev-repo: "git+https://github.com/dune-universe/ocaml-extlib.git"
 bug-reports: "https://github.com/ygrek/ocaml-extlib/issues"
 doc: ["http://ygrek.org.ua/p/extlib/doc/"]
 license: "LGPL-2.1 with OCaml linking exception"

--- a/packages/fmt/fmt.0.8.5+dune/opam
+++ b/packages/fmt/fmt.0.8.5+dune/opam
@@ -6,7 +6,7 @@ authors: [
 ]
 homepage: "http://erratique.ch/software/fmt"
 doc: "http://erratique.ch/software/fmt"
-dev-repo: "git+http://erratique.ch/repos/fmt.git"
+dev-repo: "git+https://github.com/dune-universe/fmt.git"
 bug-reports: "https://github.com/dbuenzli/fmt/issues"
 tags: [ "string" "format" "pretty-print" "org:erratique" ]
 license: "ISC"

--- a/packages/fpath/fpath.0.7.2+dune/opam
+++ b/packages/fpath/fpath.0.7.2+dune/opam
@@ -3,7 +3,7 @@ maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
 authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
 homepage: "http://erratique.ch/software/fpath"
 doc: "http://erratique.ch/software/fpath/doc"
-dev-repo: "git+http://erratique.ch/repos/fpath.git"
+dev-repo: "git+https://github.com/dune-universe/fpath.git"
 bug-reports: "https://github.com/dbuenzli/fpath/issues"
 tags: [ "file" "system" "path" "org:erratique" ]
 license: "ISC"

--- a/packages/hashcons/hashcons.1.3+dune/opam
+++ b/packages/hashcons/hashcons.1.3+dune/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 maintainer:   "sheets@alum.mit.edu"
 homepage:     "https://github.com/backtracking/ocaml-hashcons"
-dev-repo: "git+https://github.com/backtracking/ocaml-hashcons.git"
+dev-repo: "git+https://github.com/dune-universe/ocaml-hashcons.git"
 bug-reports:  "https://github.com/backtracking/ocaml-hashcons/issues"
 authors:      [ "Jean-Christophe Filliatre" ]
 license: "LGPL-2.1 with OCaml linking exception"

--- a/packages/jsonm/jsonm.1.0.1+dune/opam
+++ b/packages/jsonm/jsonm.1.0.1+dune/opam
@@ -3,7 +3,7 @@ maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
 authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
 homepage: "http://erratique.ch/software/jsonm"
 doc: "http://erratique.ch/software/jsonm/doc/Jsonm"
-dev-repo: "git+http://erratique.ch/repos/jsonm.git"
+dev-repo: "git+https://github.com/dune-universe/jsonm.git"
 bug-reports: "https://github.com/dbuenzli/jsonm/issues"
 tags: [ "json" "codec" "org:erratique" ]
 license: "ISC"

--- a/packages/logs/logs.0.6.2+dune/opam
+++ b/packages/logs/logs.0.6.2+dune/opam
@@ -3,7 +3,7 @@ maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
 authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
 homepage: "http://erratique.ch/software/logs"
 doc: "http://erratique.ch/software/logs/doc"
-dev-repo: "git+http://erratique.ch/repos/logs.git"
+dev-repo: "git+https://github.com/dune-universe/logs.git"
 bug-reports: "https://github.com/dbuenzli/logs/issues"
 tags: [ "log" "system" "org:erratique" ]
 license: "ISC"

--- a/packages/lru/lru.0.2.0+dune/opam
+++ b/packages/lru/lru.0.2.0+dune/opam
@@ -4,7 +4,7 @@ authors: ["David Kaloper Meršinjak <david@numm.org>"]
 homepage: "https://github.com/pqwy/lru"
 doc: "https://pqwy.github.io/lru/doc"
 license: "ISC"
-dev-repo: "git+https://github.com/pqwy/lru.git"
+dev-repo: "git+https://github.com/dune-universe/lru.git"
 bug-reports: "https://github.com/pqwy/lru/issues"
 tags: ["data-structure"]
 depends: [

--- a/packages/mirage-entropy/mirage-entropy.0.4.1+dune/opam
+++ b/packages/mirage-entropy/mirage-entropy.0.4.1+dune/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 name:         "mirage-entropy"
 homepage:     "https://github.com/mirage/mirage-entropy"
-dev-repo: "git+https://github.com/mirage/mirage-entropy.git"
+dev-repo: "git+https://github.com/dune-universe/mirage-entropy.git"
 bug-reports:  "https://github.com/mirage/mirage-entropy/issues"
 doc:          "https://mirage.github.io/mirage-entropy/doc"
 maintainer:   "david@numm.org"

--- a/packages/mirage-xen/mirage-xen.3.1.0+dune/opam
+++ b/packages/mirage-xen/mirage-xen.3.1.0+dune/opam
@@ -3,7 +3,7 @@ maintainer:   "anil@recoil.org"
 authors:      "The MirageOS team"
 homepage:     "https://github.com/mirage/mirage-xen"
 bug-reports:  "https://github.com/mirage/mirage-xen/issues/"
-dev-repo:     "git+https://github.com/mirage/mirage-xen.git"
+dev-repo: "git+https://github.com/dune-universe/mirage-xen.git"
 doc:          "https://mirage.github.io/mirage-xen/doc"
 license:      "ISC"
 tags:         ["org:mirage"]

--- a/packages/mirage-xen/mirage-xen.3.3.0+dune/opam
+++ b/packages/mirage-xen/mirage-xen.3.3.0+dune/opam
@@ -3,7 +3,7 @@ maintainer:   "anil@recoil.org"
 authors:      "The MirageOS team"
 homepage:     "https://github.com/mirage/mirage-xen"
 bug-reports:  "https://github.com/mirage/mirage-xen/issues/"
-dev-repo:     "git+https://github.com/mirage/mirage-xen.git"
+dev-repo: "git+https://github.com/dune-universe/mirage-xen.git"
 doc:          "https://mirage.github.io/mirage-xen/"
 license:      "ISC"
 tags:         ["org:mirage"]

--- a/packages/mtime/mtime.1.1.0+dune/opam
+++ b/packages/mtime/mtime.1.1.0+dune/opam
@@ -3,7 +3,7 @@ maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
 authors: [ "Daniel Bünzli <daniel.buenzl i@erratique.ch>" ]
 homepage: "http://erratique.ch/software/mtime"
 doc: "http://erratique.ch/software/mtime"
-dev-repo: "git+http://erratique.ch/repos/mtime.git"
+dev-repo: "git+https://github.com/dune-universe/mtime.git"
 bug-reports: "https://github.com/dbuenzli/mtime/issues"
 tags: [ "time" "monotonic" "system" "org:erratique" ]
 license: "ISC"

--- a/packages/nocrypto/nocrypto.0.5.4+dune/opam
+++ b/packages/nocrypto/nocrypto.0.5.4+dune/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 homepage:     "https://github.com/mirleft/ocaml-nocrypto"
-dev-repo: "git+https://github.com/mirleft/ocaml-nocrypto.git"
+dev-repo: "git+https://github.com/dune-universe/ocaml-nocrypto.git"
 bug-reports:  "https://github.com/mirleft/ocaml-nocrypto/issues"
 doc:          "https://mirleft.github.io/ocaml-nocrypto/doc"
 authors:      ["David Kaloper <david@numm.org>"]

--- a/packages/ocamlgraph/ocamlgraph.1.8.7+dune/opam
+++ b/packages/ocamlgraph/ocamlgraph.1.8.7+dune/opam
@@ -8,7 +8,7 @@ authors: [
 homepage: "http://ocamlgraph.lri.fr/"
 license: "GNU Library General Public License version 2.1"
 doc: ["http://ocamlgraph.lri.fr/doc"]
-dev-repo: "git+https://github.com/backtracking/ocamlgraph.git"
+dev-repo: "git+https://github.com/dune-universe/ocamlgraph.git"
 bug-reports: "https://github.com/backtracking/ocamlgraph/issues"
 
 tags: [

--- a/packages/ocamlgraph/ocamlgraph.1.8.8+dune/opam
+++ b/packages/ocamlgraph/ocamlgraph.1.8.8+dune/opam
@@ -8,7 +8,7 @@ authors: [
 homepage: "http://ocamlgraph.lri.fr/"
 license: "GNU Library General Public License version 2.1"
 doc: ["http://ocamlgraph.lri.fr/doc"]
-dev-repo: "git+https://github.com/backtracking/ocamlgraph.git"
+dev-repo: "git+https://github.com/dune-universe/ocamlgraph.git"
 bug-reports: "https://github.com/backtracking/ocamlgraph/issues"
 
 tags: [

--- a/packages/ocplib-endian/ocplib-endian.1.0+dune/opam
+++ b/packages/ocplib-endian/ocplib-endian.1.0+dune/opam
@@ -8,7 +8,7 @@ depends: [
   "base-bytes"
   "cppo" {>= "1.1.0"}
 ]
-dev-repo: "git+https://github.com/OCamlPro/ocplib-endian.git"
+dev-repo: "git+https://github.com/dune-universe/ocplib-endian.git"
 bug-reports: "https://github.com/OCamlPro/ocplib-endian/issues"
 synopsis:
   "Optimised functions to read and write int16/32/64 from strings and bigarrays, based on new primitives added in version 4.01."

--- a/packages/opam-depext/opam-depext.2.0+dune/opam
+++ b/packages/opam-depext/opam-depext.2.0+dune/opam
@@ -7,7 +7,7 @@ authors: ["Louis Gesbert <louis.gesbert@ocamlpro.com>"
 homepage: "https://github.com/ocaml/opam-depext"
 bug-reports: "https://github.com/ocaml/opam-depext/issues"
 license: "LGPL-2.1 with OCaml linking exception"
-dev-repo: "https://github.com/ocaml/opam-depext.git#2.0"
+dev-repo: "git+https://github.com/dune-universe/opam-depext.git"
 depends: [ "dune" {build} ]
 available: [ opam-version >= "2.0.0~beta5" ]
 tags: "flags:plugin"

--- a/packages/opam-file-format/opam-file-format.2.0.0+dune/opam
+++ b/packages/opam-file-format/opam-file-format.2.0.0+dune/opam
@@ -4,7 +4,7 @@ authors: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
 homepage: "https://opam.ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-file-format/issues"
 license: "LGPL-2.1 with OCaml linking exception"
-dev-repo: "git+https://github.com/ocaml/opam-file-format"
+dev-repo: "git+https://github.com/dune-universe/opam-file-format.git"
 synopsis: "Parser and printer for the opam file syntax"
 depends: [
   "dune" {build}

--- a/packages/opam-file-format/opam-file-format.2.0.0~rc2+dune/opam
+++ b/packages/opam-file-format/opam-file-format.2.0.0~rc2+dune/opam
@@ -4,7 +4,7 @@ authors: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
 homepage: "https://opam.ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-file-format/issues"
 license: "LGPL-2.1 with OCaml linking exception"
-dev-repo: "git+https://github.com/ocaml/opam-file-format"
+dev-repo: "git+https://github.com/dune-universe/opam-file-format.git"
 synopsis: "Parser and printer for the opam file syntax"
 depends: [
   "dune" {build}

--- a/packages/psq/psq.0.1.0+dune/opam
+++ b/packages/psq/psq.0.1.0+dune/opam
@@ -4,7 +4,7 @@ authors: ["David Kaloper Meršinjak <david@numm.org>"]
 homepage: "https://github.com/pqwy/psq"
 doc: "https://pqwy.github.io/psq/doc"
 license: "ISC"
-dev-repo: "git+https://github.com/pqwy/psq.git"
+dev-repo: "git+https://github.com/dune-universe/psq.git"
 bug-reports: "https://github.com/pqwy/psq/issues"
 depends: [
   "dune" {build}

--- a/packages/ptime/ptime.0.8.3+dune/opam
+++ b/packages/ptime/ptime.0.8.3+dune/opam
@@ -3,7 +3,7 @@ maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
 authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
 homepage: "http://erratique.ch/software/ptime"
 doc: "http://erratique.ch/software/ptime/doc"
-dev-repo: "git+http://erratique.ch/repos/ptime.git"
+dev-repo: "git+https://github.com/dune-universe/ptime.git"
 bug-reports: "https://github.com/dbuenzli/ptime/issues"
 tags: [ "time" "posix" "system" "org:erratique" ]
 license: "ISC"

--- a/packages/ptime/ptime.0.8.4+dune/opam
+++ b/packages/ptime/ptime.0.8.4+dune/opam
@@ -3,7 +3,7 @@ maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
 authors: ["The ptime programmers"]
 homepage: "http://erratique.ch/software/ptime"
 doc: "http://erratique.ch/software/ptime/doc"
-dev-repo: "git+http://erratique.ch/repos/ptime.git"
+dev-repo: "git+https://github.com/dune-universe/ptime.git"
 bug-reports: "https://github.com/dbuenzli/ptime/issues"
 tags: [ "time" "posix" "system" "org:erratique" ]
 license: "ISC"

--- a/packages/react/react.1.2.1+dune/opam
+++ b/packages/react/react.1.2.1+dune/opam
@@ -3,7 +3,7 @@ maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
 homepage: "http://erratique.ch/software/react"
 authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
 doc: "http://erratique.ch/software/react/doc/React"
-dev-repo: "git+http://erratique.ch/repos/react.git"
+dev-repo: "git+https://github.com/dune-universe/react.git"
 bug-reports: "https://github.com/dbuenzli/react/issues"
 tags: [ "reactive" "declarative" "signal" "event" "frp" "org:erratique" ]
 license: "ISC"

--- a/packages/reactiveData/reactiveData.0.2.2+dune/opam
+++ b/packages/reactiveData/reactiveData.0.2.2+dune/opam
@@ -4,7 +4,7 @@ description: "React is an OCaml module for functional reactive programming (FRP)
 maintainer: "dev@ocsigen.org"
 authors: ["Hugo Heuzard <hugo.heuzard@gmail.com>"]
 homepage: "https://github.com/ocsigen/reactiveData"
-dev-repo: "git+https://github.com/ocsigen/reactiveData.git"
+dev-repo: "git+https://github.com/dune-universe/reactiveData.git"
 bug-reports: "https://github.com/ocsigen/reactiveData/issues"
 
 doc:"http://ocsigen.github.io/reactiveData/dev/"

--- a/packages/rresult/rresult.0.5.0+dune/opam
+++ b/packages/rresult/rresult.0.5.0+dune/opam
@@ -3,7 +3,7 @@ maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
 authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
 homepage: "http://erratique.ch/software/rresult"
 doc: "http://erratique.ch/software/rresult"
-dev-repo: "git+http://erratique.ch/repos/rresult.git"
+dev-repo: "git+https://github.com/dune-universe/rresult.git"
 bug-reports: "https://github.com/dbuenzli/rresult/issues"
 tags: [ "result" "error" "declarative" "org:erratique" ]
 license: "ISC"

--- a/packages/rresult/rresult.0.6.0+dune/opam
+++ b/packages/rresult/rresult.0.6.0+dune/opam
@@ -3,7 +3,7 @@ maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
 authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
 homepage: "http://erratique.ch/software/rresult"
 doc: "http://erratique.ch/software/rresult"
-dev-repo: "git+http://erratique.ch/repos/rresult.git"
+dev-repo: "git+https://github.com/dune-universe/rresult.git"
 bug-reports: "https://github.com/dbuenzli/rresult/issues"
 tags: [ "result" "error" "declarative" "org:erratique" ]
 license: "ISC"

--- a/packages/textwrap/textwrap.0.2+dune/opam
+++ b/packages/textwrap/textwrap.0.2+dune/opam
@@ -3,7 +3,7 @@ maintainer: "Sergei Lebedev <superbobry@gmail.com>"
 authors: "Sergei Lebedev <superbobry@gmail.com>"
 homepage: "https://github.com/superbobry/ocaml-textwrap"
 bug-reports: "https://github.com/superbobry/ocaml-textwrap/issues"
-dev-repo: "git+https://github.com/superbobry/ocaml-textwrap.git"
+dev-repo: "git+https://github.com/dune-universe/ocaml-textwrap.git"
 license: "MIT"
 depends: [
   "dune" {build}

--- a/packages/tls/tls.0.10.1+dune/opam
+++ b/packages/tls/tls.0.10.1+dune/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 name:         "tls"
 homepage:     "https://github.com/mirleft/ocaml-tls"
-dev-repo:     "git+https://github.com/mirleft/ocaml-tls.git"
+dev-repo: "git+https://github.com/dune-universe/ocaml-tls.git"
 bug-reports:  "https://github.com/mirleft/ocaml-tls/issues"
 doc:          "https://mirleft.github.io/ocaml-tls/doc"
 author:       ["David Kaloper <david@numm.org>" "Hannes Mehnert <hannes@mehnert.org>"]

--- a/packages/tls/tls.0.9.3+dune/opam
+++ b/packages/tls/tls.0.9.3+dune/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 name:         "tls"
 homepage:     "https://github.com/mirleft/ocaml-tls"
-dev-repo:     "git+https://github.com/mirleft/ocaml-tls.git"
+dev-repo: "git+https://github.com/dune-universe/ocaml-tls.git"
 bug-reports:  "https://github.com/mirleft/ocaml-tls/issues"
 doc:          "https://mirleft.github.io/ocaml-tls/doc"
 author:       ["David Kaloper <david@numm.org>" "Hannes Mehnert <hannes@mehnert.org>"]

--- a/packages/topkg/topkg.0.9.1+dune/opam
+++ b/packages/topkg/topkg.0.9.1+dune/opam
@@ -4,7 +4,7 @@ authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
 homepage: "http://erratique.ch/software/topkg"
 doc: "http://erratique.ch/software/topkg/doc"
 license: "ISC"
-dev-repo: "git+http://erratique.ch/repos/topkg.git"
+dev-repo: "git+https://github.com/dune-universe/topkg.git"
 bug-reports: "https://github.com/dbuenzli/topkg/issues"
 depends: [
   "dune" {build}

--- a/packages/topkg/topkg.1.0.0+dune/opam
+++ b/packages/topkg/topkg.1.0.0+dune/opam
@@ -4,7 +4,7 @@ authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
 homepage: "http://erratique.ch/software/topkg"
 doc: "http://erratique.ch/software/topkg/doc"
 license: "ISC"
-dev-repo: "git+http://erratique.ch/repos/topkg.git"
+dev-repo: "git+https://github.com/dune-universe/topkg.git"
 bug-reports: "https://github.com/dbuenzli/topkg/issues"
 depends: [
   "dune" {build}

--- a/packages/uuidm/uuidm.0.9.6+dune/opam
+++ b/packages/uuidm/uuidm.0.9.6+dune/opam
@@ -3,7 +3,7 @@ maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
 authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
 homepage: "http://erratique.ch/software/uuidm"
 doc: "http://erratique.ch/software/uuidm/doc/Uuidm"
-dev-repo: "git+http://erratique.ch/repos/uuidm.git"
+dev-repo: "git+https://github.com/dune-universe/uuidm.git"
 bug-reports: "https://github.com/dbuenzli/uuidm/issues"
 tags: [ "uuid" "codec" "org:erratique" ]
 license: "ISC"

--- a/packages/uutf/uutf.1.0.1+dune/opam
+++ b/packages/uutf/uutf.1.0.1+dune/opam
@@ -3,7 +3,7 @@ maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
 authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
 homepage: "http://erratique.ch/software/uutf"
 doc: "http://erratique.ch/software/uutf/doc/Uutf"
-dev-repo: "git+http://erratique.ch/repos/uutf.git"
+dev-repo: "git+https://github.com/dune-universe/uutf.git"
 bug-reports: "https://github.com/dbuenzli/uutf/issues"
 tags: [ "unicode" "text" "utf-8" "utf-16" "codec" "org:erratique" ]
 license: "ISC"

--- a/packages/uutf/uutf.1.0.2+dune/opam
+++ b/packages/uutf/uutf.1.0.2+dune/opam
@@ -3,7 +3,7 @@ maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
 authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
 homepage: "http://erratique.ch/software/uutf"
 doc: "http://erratique.ch/software/uutf/doc/Uutf"
-dev-repo: "git+http://erratique.ch/repos/uutf.git"
+dev-repo: "git+https://github.com/dune-universe/uutf.git"
 bug-reports: "https://github.com/dbuenzli/uutf/issues"
 tags: [ "unicode" "text" "utf-8" "utf-16" "codec" "org:erratique" ]
 license: "ISC"

--- a/packages/webbrowser/webbrowser.0.6.1+dune/opam
+++ b/packages/webbrowser/webbrowser.0.6.1+dune/opam
@@ -4,7 +4,7 @@ authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
 homepage: "http://erratique.ch/software/webbrowser"
 doc: "http://erratique.ch/software/webbrowser/doc"
 license: "ISC"
-dev-repo: "git+http://erratique.ch/repos/webbrowser.git"
+dev-repo: "git+https://github.com/dune-universe/webbrowser.git"
 bug-reports: "https://github.com/dbuenzli/webbrowser/issues"
 tags: [ "web" "http" "uri" "browser" "cli" "org:erratique"]
 depends: [

--- a/packages/xmlm/xmlm.1.3.0+dune/opam
+++ b/packages/xmlm/xmlm.1.3.0+dune/opam
@@ -2,7 +2,7 @@ opam-version: "2.0"
 maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
 authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
 homepage: "http://erratique.ch/software/xmlm"
-dev-repo: "git+http://erratique.ch/repos/xmlm.git"
+dev-repo: "git+https://github.com/dune-universe/xmlm.git"
 bug-reports: "https://github.com/dbuenzli/xmlm/issues"
 doc: "http://erratique.ch/software/xmlm/doc/Xmlm"
 tags: [ "xml" "codec" "org:erratique" ]


### PR DESCRIPTION
In #1, I forgot to update the `dev-repo` field.

I did not spotted this before because I was using packages with non-github `dev-repo` and archive url. In this case, duniverse use the archive url or crash