### PR TITLE
logs.0.6.3+dune

### DIFF
--- a/packages/logs/logs.0.6.3+dune/opam
+++ b/packages/logs/logs.0.6.3+dune/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["The logs programmers"]
+homepage: "https://erratique.ch/software/logs"
+doc: "https://erratique.ch/software/logs/doc"
+bug-reports: "https://github.com/dbuenzli/logs/issues"
+tags: [ "log" "system" "org:erratique" ]
+license: "ISC"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {build}
+  "mtime" {with-test} ]
+depopts: [
+  "js_of_ocaml"
+  "fmt"
+  "cmdliner"
+  "lwt" ]
+conflicts: [
+  "js_of_ocaml" { < "3.3.0" } ]
+
+synopsis: """Logging infrastructure for OCaml"""
+description: """\
+
+Logs provides a logging infrastructure for OCaml. Logging is performed
+on sources whose reporting level can be set independently. Log message
+report is decoupled from logging and is handled by a reporter.
+
+A few optional log reporters are distributed with the base library and
+the API easily allows to implement your own.
+
+`Logs` has no dependencies. The optional `Logs_fmt` reporter on OCaml
+formatters depends on [Fmt][fmt].  The optional `Logs_browser`
+reporter that reports to the web browser console depends on
+[js_of_ocaml][jsoo]. The optional `Logs_cli` library that provides
+command line support for controlling Logs depends on
+[`Cmdliner`][cmdliner]. The optional `Logs_lwt` library that provides
+Lwt logging functions depends on [`Lwt`][lwt]
+
+Logs and its reporters are distributed under the ISC license.
+
+[fmt]: http://erratique.ch/software/fmt
+[jsoo]: http://ocsigen.org/js_of_ocaml/
+[cmdliner]: http://erratique.ch/software/cmdliner
+[lwt]: http://ocsigen.org/lwt/
+"""
+
+build: [[ "dune" "build" "-p" name ]]
+dev-repo: "git+https://github.com/dune-universe/logs.git"
+url {
+  src: "git://github.com/dune-universe/logs.git#duniverse-v0.6.3"
+}


### PR DESCRIPTION
PR on opam: https://github.com/ocaml/opam-repository/pull/13991

I pushed directly to https://github.com/dune-universe/logs/tree/duniverse-v0.6.3.

Note that `opam install logs` will fail because dune will try to build libraries that depend on optional dependencies.