### PR TITLE
Release @avsm's dune port of ocamlfind

### DIFF
--- a/packages/ocamlfind/ocamlfind.1.8.0+dune/opam
+++ b/packages/ocamlfind/ocamlfind.1.8.0+dune/opam
@@ -1,0 +1,66 @@
+opam-version: "2.0"
+maintainer:   "Thomas Gazagnaire <thomas@gazagnaire.org>"
+homepage:     "http://projects.camlcity.org/projects/findlib.html"
+bug-reports:  "https://gitlab.camlcity.org/gerd/lib-findlib/issues"
+dev-repo: "git+https://github.com/dune-universe/lib-findlib.git"
+patches: ["no-awk-check.patch"]
+build: [
+  [
+    "./configure"
+    "-bindir"
+    bin
+    "-sitelib"
+    lib
+    "-mandir"
+    man
+    "-config"
+    "%{lib}%/findlib.conf"
+    "-no-custom"
+    "-no-camlp4" {!ocaml:preinstalled & ocaml:version >= "4.02.0"}
+    "-no-topfind" {ocaml:preinstalled}
+  ]
+  [make "all"]
+  [make "opt"] {ocaml:native}
+]
+install: [
+  [make "install"]
+  ["install" "-m" "0755" "ocaml-stub" "%{bin}%/ocaml"] {ocaml:preinstalled}
+]
+remove: [
+  ["ocamlfind" "remove" "bytes"]
+  [
+    "./configure"
+    "-bindir"
+    bin
+    "-sitelib"
+    lib
+    "-mandir"
+    man
+    "-config"
+    "%{lib}%/findlib.conf"
+    "-no-camlp4" {!ocaml:preinstalled & ocaml:version >= "4.02.0"}
+    "-no-topfind" {ocaml:preinstalled}
+  ]
+  [make "uninstall"]
+  ["rm" "-f" "%{bin}%/ocaml"] {ocaml:preinstalled}
+]
+depends: [
+  "ocaml" {>= "4.00.0"}
+  "conf-m4" {build}
+]
+synopsis: "A library manager for OCaml"
+description: """
+Findlib is a library manager for OCaml. It provides a convention how
+to store libraries, and a file format ("META") to describe the
+properties of libraries. There is also a tool (ocamlfind) for
+interpreting the META files, so that it is very easy to use libraries
+in programs and scripts."""
+authors: "Gerd Stolpmann <gerd@gerd-stolpmann.de>"
+extra-files: [
+  ["ocamlfind.install" "md5=06f2c282ab52d93aa6adeeadd82a2543"]
+  ["ocaml-stub" "md5=181f259c9e0bad9ef523e7d4abfdf87a"]
+  ["no-awk-check.patch" "md5=0378123bf1a45fccdea434c053ddb687"]
+]
+url {
+  src: "git+https://github.com/dune-universe/lib-findlib#v1.8.0+dune"
+}


### PR DESCRIPTION
We've been having issues with ocamlfind in `duniverse` recently (see https://github.com/avsm/duniverse/pull/14#issuecomment-484426225) so I thought that might help.

Just took the port from https://github.com/dune-universe/lib-findlib/tree/duniverse-1.8.0.