### PR TITLE
cmdliner 1.0.4: also use upstream tarball since it includes dune files

### DIFF
--- a/packages/cmdliner/cmdliner.1.0.4+dune/opam
+++ b/packages/cmdliner/cmdliner.1.0.4+dune/opam
@@ -28,5 +28,5 @@ Cmdliner has no dependencies and is distributed under the ISC license.
 """
 build: [[ "dune" "build" "-p" name ]]
 url {
-  src: "git://github.com/dune-universe/cmdliner.git#duniverse-v1.0.3"
+  src: "git://github.com/dbuenzli/cmdliner.git#v1.0.4"
 }

--- a/packages/cmdliner/cmdliner.1.0.4+dune/opam
+++ b/packages/cmdliner/cmdliner.1.0.4+dune/opam
@@ -3,7 +3,7 @@ maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
 authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
 homepage: "http://erratique.ch/software/cmdliner"
 doc: "http://erratique.ch/software/cmdliner/doc/Cmdliner"
-dev-repo: "git+https://github.com/dune-universe/cmdliner.git"
+dev-repo: "git+https://github.com/dbuenzli/cmdliner.git"
 bug-reports: "https://github.com/dbuenzli/cmdliner/issues"
 tags: [ "cli" "system" "declarative" "org:erratique" ]
 license: "ISC"


### PR DESCRIPTION
(this overlay is needed to add dune to the build deps in opam)