### PR TITLE
Add ocamlfind 1.8.1

### DIFF
--- a/packages/ocamlfind/ocamlfind.1.8.1+dune/opam
+++ b/packages/ocamlfind/ocamlfind.1.8.1+dune/opam
@@ -28,5 +28,5 @@ interpreting the META files, so that it is very easy to use libraries
 in programs and scripts."""
 authors: "Gerd Stolpmann <gerd@gerd-stolpmann.de>"
 url {
-  src: "git+https://github.com/dune-universe/lib-findlib#duniverse-1.8.0"
+  src: "git+https://github.com/dune-universe/lib-findlib#duniverse-1.8.1"
 }


### PR DESCRIPTION
It appears there is some kind of hack in here and `ocamlfind` and `findlib` are split, the former depending on the latter.

This updates the `ocamlfind` package in response to #42 !