### PR TITLE
Add a seq 0.1 dune port

### DIFF
--- a/packages/seq/seq.0.1+dune/opam
+++ b/packages/seq/seq.0.1+dune/opam
@@ -1,0 +1,20 @@
+opam-version: "2.0"
+name: "seq"
+version: "0.1"
+author: "Simon Cruanes"
+maintainer: "simon.cruanes.2007@m4x.org"
+license: "LGPL2.1"
+build: [
+  [ "dune" "build" "-p" name ]
+]
+depends: [
+  "dune"
+]
+tags: [ "iterator" "seq" "pure" "list" "compatibility" "cascade" ]
+homepage: "https://github.com/c-cube/seq/"
+bug-reports: "https://github.com/c-cube/seq/issues"
+dev-repo: "git+https://github.com/dune-universe/seq.git"
+synopsis: "Compatibility package for OCaml's standard iterator type starting from 4.07"
+url {
+  src: "git://github.com/dune-universe/seq.git#duniverse-0.1"
+}

--- a/packages/seq/seq.base+dune/opam
+++ b/packages/seq/seq.base+dune/opam
@@ -1,6 +1,5 @@
 opam-version: "2.0"
 name: "seq"
-version: "0.1"
 author: "Simon Cruanes"
 maintainer: "simon.cruanes.2007@m4x.org"
 license: "LGPL2.1"


### PR DESCRIPTION
This ports the `seq` compatibility package to `dune` so that it works well within a duniverse.

You can take a look [here](https://github.com/dune-universe/seq/commit/8feae7e02820f656c6c2ebe5a126b20d3eecb76e). Having conditional actions would be great but unfortunately we have to without it for now.