### PR TITLE
Turn uchar into a dummy package that will satisfy both opam-monorepo and opam

### DIFF
--- a/packages/uchar/uchar.0.0.2+dune/opam
+++ b/packages/uchar/uchar.0.0.2+dune/opam
@@ -1,16 +1,14 @@
 opam-version: "2.0"
-maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
 homepage: "http://ocaml.org"
-authors: ["The OCaml authors"]
 doc: "https://ocaml.github.io/uchar/"
+dev-repo: "https://github.com/ocaml/uchar.git"
 bug-reports: "https://github.com/ocaml/uchar/issues"
 tags: [ "text" "character" "unicode" "compatibility" "org:ocaml.org" ]
 license: "typeof OCaml system"
-depends: [
-  "ocaml" {>= "4.03.0"}
-]
-synopsis: "Dummy package for OCaml's Uchar module"
-description: """
-This package is just a dummy package since UChar is included
-with OCaml 4.03.0 and higher.
-"""
+depends: [ "dune" "ocaml" {>= "4.03"} ]
+synopsis: "Dummy but non virtual package to satisfy both opam-monorepo and opam"
+url {
+  src: "git+https://github.com/dune-universe/uchar.git#dune-universe-v0.0.2"
+}


### PR DESCRIPTION
The virtual package worked for opam-monorepo but trying to opam install the generated lockfiles would fail because uchar.0.0.2+dune wasn't pinned since it had no sources and doesn't exist outside opam-overlays.