### PR TITLE
Add dune port of opam-file-format 2.1.0

### DIFF
--- a/packages/opam-file-format/opam-file-format.2.1.0+dune/opam
+++ b/packages/opam-file-format/opam-file-format.2.1.0+dune/opam
@@ -1,0 +1,19 @@
+opam-version: "2.0"
+synopsis: "Parser and printer for the opam file syntax"
+maintainer: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+authors: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-file-format/issues"
+depends: ["ocaml" "dune"]
+build: [
+  ["dune" "build" "-p" name "-j" jobs "@install" "@doc" {with-doc}]
+]
+dev-repo: "git+https://github.com/ocaml/opam-file-format"
+url {
+  src: "https://github.com/ocaml/opam-file-format/archive/2.1.0.tar.gz"
+  checksum: [
+    "md5=f3daefb6f6041d6c1baed0c63d88f0fb"
+    "sha512=b948545497de0386457a9b5772924572249e38164aa49d5ab2ac9442d1231a56a3b8132a95197d74cbbe34336a7edc04eaca351a8763c4a009a512085ca0ab25"
+  ]
+}


### PR DESCRIPTION
opam-file-format has a depopts on dune which doesn't satisfy opam-monorepo's build system detection logic. We should probably
consider a better way to detect the build system, maybe using the `build` field from the opam file but that wouldn't have necessarily
worked here either. A specific field in the opam file with the list of supported build systems would be great but in the meantime this port does the job.