### PR TITLE
Use tarball as src for asetmap

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -15,7 +15,7 @@ steps:
   - opam repo add overlays .
   - opam update -uy
   - opam exec -- ocaml -version
-  - env OPAMERRLOGLEN=0 OPAMJOBS=40 opam --yes depext -uiy `./list-overrides.sh`
+  - env OPAMERRLOGLEN=0 OPAMJOBS=40 opam --yes depext -uiy `./list-overrides.sh -distinct`
 - name: outofdate
   image: ocaml/opam2:4.10
   commands:

--- a/list-overrides.sh
+++ b/list-overrides.sh
@@ -1,7 +1,9 @@
 #!/bin/sh -e
 
 if [ "$1" = "-bare" ]; then
-  find packages -type d -exec basename {} \; -mindepth 2 -maxdepth 2 | awk -F '.' '{print $1}'
+  find packages -type d -exec basename {} \; -mindepth 2 -maxdepth 2 | awk -F '.' '{print $1}' | sort | uniq
+elif [ "$1" = "-distinct" ]; then 
+  find packages -type d -exec basename {} \; -mindepth 2 -maxdepth 2 | sort -r | awk -F '.' '{ st = index($0,".");print substr($0,st+1) " " $1}' | uniq -f 1 | awk -F ' ' '{print $2 "." $1}' | sort
 else
-  find packages -type d -exec basename {} \; -mindepth 2 -maxdepth 2
+  find packages -type d -exec basename {} \; -mindepth 2 -maxdepth 2 | sort
 fi

--- a/packages/asetmap/asetmap.0.8.1+dune/opam
+++ b/packages/asetmap/asetmap.0.8.1+dune/opam
@@ -21,5 +21,6 @@ pretty-printers for the data types.
 asetmap has no dependency is distributed under the ISC license."""
 build: [[ "dune" "build" "-p" name ]]
 url {
-  src: "git://github.com/dune-universe/asetmap.git#duniverse-v0.8.1"
+  src: "https://github.com/dune-universe/asetmap/archive/v0.8.1+dune.tar.gz"
+  checksum: "sha256=45883d0fd0f1653afa59eb25c36d8b56c15f9f4c950212140d95bd5267cfd810"
 }


### PR DESCRIPTION
First step for https://github.com/dune-universe/opam-overlays/issues/73 

So I have a script to automate the process, but I want to be sure that it works for a single package beforehand. 
Basically for each package that have a git url, it makes a tag on the corresponding branch with the version number (`vxxx+dune`) and push it, then fetches the resulting archive to compute the SHA256 (that is used for caching) and finally updates opam overlays.

I'm not sure about the last steps, as maybe it's more robust to make a proper github release, but I had troubles automating the `dune-release` process as it does a lot of magic. 