### PR TITLE
When having multiple packages, CI tests last version

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -15,7 +15,7 @@ steps:
   - opam repo add overlays .
   - opam update -uy
   - opam exec -- ocaml -version
-  - env OPAMERRLOGLEN=0 OPAMJOBS=40 opam --yes depext -uiy `./list-overrides.sh`
+  - env OPAMERRLOGLEN=0 OPAMJOBS=40 opam --yes depext -uiy `./list-overrides.sh -distinct`
 - name: outofdate
   image: ocaml/opam2:4.10
   commands:

--- a/list-overrides.sh
+++ b/list-overrides.sh
@@ -1,7 +1,9 @@
 #!/bin/sh -e
 
 if [ "$1" = "-bare" ]; then
-  find packages -type d -exec basename {} \; -mindepth 2 -maxdepth 2 | awk -F '.' '{print $1}'
+  find packages -type d -exec basename {} \; -mindepth 2 -maxdepth 2 | awk -F '.' '{print $1}' | sort | uniq
+elif [ "$1" = "-distinct" ]; then 
+  find packages -type d -exec basename {} \; -mindepth 2 -maxdepth 2 | sort -r | awk -F '.' '{ st = index($0,".");print substr($0,st+1) " " $1}' | uniq -f 1 | awk -F ' ' '{print $2 "." $1}' | sort
 else
-  find packages -type d -exec basename {} \; -mindepth 2 -maxdepth 2
+  find packages -type d -exec basename {} \; -mindepth 2 -maxdepth 2 | sort
 fi


### PR DESCRIPTION
By having two different versions in opam-overlays, `opam-file-format` breaks the CI in the following PR https://github.com/dune-universe/opam-overlays/pull/72.
The drone script tries to install every opam-overlays package at once, but fails because it can't satisfy the constraints (two different versions of `opam-file-format`). I added an option in `list-overrides.sh` to select the last version when several are available. 