### PR TITLE
More accurate dev-repo metadata

### DIFF
--- a/packages/asetmap/asetmap.0.8.1+dune/opam
+++ b/packages/asetmap/asetmap.0.8.1+dune/opam
@@ -4,7 +4,7 @@ authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
 homepage: "http://erratique.ch/software/asetmap"
 doc: "http://erratique.ch/software/asetmap/doc"
 license: "ISC"
-dev-repo: "git+https://github.com/dune-universe/asetmap.git"
+dev-repo: "git+https://github.com/dune-universe/asetmap.git#duniverse-v0.8.1"
 bug-reports: "https://github.com/dbuenzli/asetmap/issues"
 tags: [ "org:erratique" "set" "map" "stdlib" ]
 depends: [

--- a/packages/astring/astring.0.8.5+dune/opam
+++ b/packages/astring/astring.0.8.5+dune/opam
@@ -3,7 +3,7 @@ maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
 authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
 homepage: "http://erratique.ch/software/astring"
 doc: "http://erratique.ch/software/astring/doc"
-dev-repo: "git+https://github.com/dune-universe/astring.git"
+dev-repo: "git+https://github.com/dune-universe/astring.git#duniverse-v0.8.5"
 bug-reports: "https://github.com/dbuenzli/astring/issues"
 tags: [ "string" "org:erratique" ]
 license: "ISC"

--- a/packages/bheap/bheap.1.0.0+dune/opam
+++ b/packages/bheap/bheap.1.0.0+dune/opam
@@ -12,7 +12,7 @@ build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name]
 ]
-dev-repo: "git+https://github.com/dune-universe/bheap.git"
+dev-repo: "git+https://github.com/dune-universe/bheap.git#to-dune"
 url {
   src:
     "git://github.com/dune-universe/bheap.git#to-dune"

--- a/packages/bos/bos.0.2.0+dune/opam
+++ b/packages/bos/bos.0.2.0+dune/opam
@@ -3,7 +3,7 @@ maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
 authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
 homepage: "http://erratique.ch/software/bos"
 doc: "http://erratique.ch/software/bos/doc"
-dev-repo: "git+https://github.com/dune-universe/bos.git"
+dev-repo: "git+https://github.com/dune-universe/bos.git#duniverse-v0.2.0"
 bug-reports: "https://github.com/dbuenzli/bos/issues"
 tags: [ "os" "system" "cli" "command" "file" "path" "log" "unix" "org:erratique" ]
 license: "ISC"

--- a/packages/charInfo_width/charInfo_width.1.1.0+dune/opam
+++ b/packages/charInfo_width/charInfo_width.1.1.0+dune/opam
@@ -4,7 +4,7 @@ authors: [ "ZAN DoYe" ]
 homepage: "https://bitbucket.org/zandoye/charinfo_width/"
 bug-reports: "https://bitbucket.org/zandoye/charinfo_width/issues"
 license: "MIT"
-dev-repo: "https://github.com/dune-universe/charinfo_width"
+dev-repo: "git+https://github.com/dune-universe/charinfo_width.git#duniverse-1.1.0"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test & (ocaml:version >= "4.04.0")}

--- a/packages/cmdliner/cmdliner.1.0.4+dune/opam
+++ b/packages/cmdliner/cmdliner.1.0.4+dune/opam
@@ -3,7 +3,7 @@ maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
 authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
 homepage: "http://erratique.ch/software/cmdliner"
 doc: "http://erratique.ch/software/cmdliner/doc/Cmdliner"
-dev-repo: "git+https://github.com/dune-universe/cmdliner.git"
+dev-repo: "git+https://github.com/dune-universe/cmdliner.git#duniverse-v1.0.4"
 bug-reports: "https://github.com/dbuenzli/cmdliner/issues"
 tags: [ "cli" "system" "declarative" "org:erratique" ]
 license: "ISC"

--- a/packages/ctypes-foreign/ctypes-foreign.0.17.1+dune/opam
+++ b/packages/ctypes-foreign/ctypes-foreign.0.17.1+dune/opam
@@ -48,7 +48,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
-dev-repo: "git+https://github.com/avsm/ocaml-ctypes.git"
+dev-repo: "git+https://github.com/avsm/ocaml-ctypes.git#dune-port"
 url {
   src: "git+https://github.com/avsm/ocaml-ctypes.git#dune-port"
 }

--- a/packages/ctypes/ctypes.0.17.1+dune/opam
+++ b/packages/ctypes/ctypes.0.17.1+dune/opam
@@ -38,7 +38,7 @@ build: [
   ["dune" "subst"]
   ["dune" "build" "-p" name "-j" jobs]
 ]
-dev-repo: "git+https://github.com/avsm/ocaml-ctypes.git"
+dev-repo: "git+https://github.com/avsm/ocaml-ctypes.git#dune-port"
 url {
   src: "git+https://github.com/avsm/ocaml-ctypes.git#dune-port"
 }

--- a/packages/cudf/cudf.0.9+dune/opam
+++ b/packages/cudf/cudf.0.9+dune/opam
@@ -3,7 +3,7 @@ maintainer: "roberto@dicosmo.org"
 authors: ["Roberto di Cosmo <roberto@dicosmo.org>" "Stefano Zacchiroli" "Pietro Abate"]
 homepage: "http://www.mancoosi.org/cudf/"
 bug-reports: "https://gforge.inria.fr/tracker/?atid=13811&group_id=4385&func=browse"
-dev-repo: "git+https://github.com/dune-universe/cudf.git"
+dev-repo: "git+https://github.com/dune-universe/cudf.git#duniverse-0.9"
 depends: [
   "dune"
   "ocaml"

--- a/packages/dose3/dose3.5.0.1+dune/opam
+++ b/packages/dose3/dose3.5.0.1+dune/opam
@@ -13,7 +13,7 @@ authors: [
 homepage: "http://www.mancoosi.org/software/"
 bug-reports: "https://gforge.inria.fr/tracker/?group_id=4395"
 license: "LGPL-v3+ with OCaml linking exception"
-dev-repo: "git+https://github.com/dune-universe/dose3.git"
+dev-repo: "git+https://github.com/dune-universe/dose3.git#duniverse-5.0.1"
 depends: [
   "dune"
   "ocaml"

--- a/packages/extlib/extlib.1.7.7+dune/opam
+++ b/packages/extlib/extlib.1.7.7+dune/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 maintainer: "ygrek@autistici.org"
 homepage: "https://github.com/ygrek/ocaml-extlib"
-dev-repo: "git+https://github.com/dune-universe/ocaml-extlib.git"
+dev-repo: "git+https://github.com/dune-universe/ocaml-extlib.git#duniverse-1.7.7"
 bug-reports: "https://github.com/ygrek/ocaml-extlib/issues"
 doc: ["http://ygrek.org.ua/p/extlib/doc/"]
 license: "LGPL-2.1 with OCaml linking exception"

--- a/packages/findlib/findlib.1.8.1+dune/opam
+++ b/packages/findlib/findlib.1.8.1+dune/opam
@@ -2,7 +2,7 @@ opam-version: "2.0"
 maintainer:   "Anil Madhavapeddy <anil@recoil.org>"
 homepage:     "http://projects.camlcity.org/projects/findlib.html"
 bug-reports:  "https://gitlab.camlcity.org/gerd/lib-findlib/issues"
-dev-repo: "git+https://github.com/dune-universe/lib-findlib.git"
+dev-repo: "git+https://github.com/dune-universe/lib-findlib.git#duniverse-1.8.1"
 build: [
   [ "env" "FINDLIB_PREFIX=%{lib}%" "dune" "build" "-p" name "-j" jobs ]
 ]

--- a/packages/fmt/fmt.0.8.9+dune/opam
+++ b/packages/fmt/fmt.0.8.9+dune/opam
@@ -3,7 +3,7 @@ maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
 authors: [ "The fmt programmers" ]
 homepage: "https://erratique.ch/software/fmt"
 doc: "https://erratique.ch/software/fmt"
-dev-repo: "git+https://github.com/dune-universe/fmt.git"
+dev-repo: "git+https://github.com/dune-universe/fmt.git#duniverse-v0.8.9"
 bug-reports: "https://github.com/dbuenzli/fmt/issues"
 tags: [ "string" "format" "pretty-print" "org:erratique" ]
 license: "ISC"

--- a/packages/fpath/fpath.0.7.2+dune/opam
+++ b/packages/fpath/fpath.0.7.2+dune/opam
@@ -3,7 +3,7 @@ maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
 authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
 homepage: "http://erratique.ch/software/fpath"
 doc: "http://erratique.ch/software/fpath/doc"
-dev-repo: "git+https://github.com/dune-universe/fpath.git"
+dev-repo: "git+https://github.com/dune-universe/fpath.git#duniverse-v0.7.3"
 bug-reports: "https://github.com/dbuenzli/fpath/issues"
 tags: [ "file" "system" "path" "org:erratique" ]
 license: "ISC"

--- a/packages/hashcons/hashcons.1.3+dune/opam
+++ b/packages/hashcons/hashcons.1.3+dune/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 maintainer:   "sheets@alum.mit.edu"
 homepage:     "https://github.com/backtracking/ocaml-hashcons"
-dev-repo: "git+https://github.com/dune-universe/ocaml-hashcons.git"
+dev-repo: "git+https://github.com/dune-universe/ocaml-hashcons.git#duniverse-1.3"
 bug-reports:  "https://github.com/backtracking/ocaml-hashcons/issues"
 authors:      [ "Jean-Christophe Filliatre" ]
 license: "LGPL-2.1 with OCaml linking exception"

--- a/packages/hmap/hmap.0.8.0+dune/opam
+++ b/packages/hmap/hmap.0.8.0+dune/opam
@@ -4,7 +4,7 @@ authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
 homepage: "http://erratique.ch/software/hmap"
 doc: "http://erratique.ch/software/hmap/doc"
 license: "ISC"
-dev-repo: "git+http://github.com/dune-universe/hmap.git"
+dev-repo: "git+http://github.com/dune-universe/hmap.git#duniverse-v0.8.0"
 bug-reports: "http://github.com/dbuenzli/hmap/issues"
 tags: ["data-structure" "org:erratique"]
 depends: [

--- a/packages/jsonm/jsonm.1.0.1+dune/opam
+++ b/packages/jsonm/jsonm.1.0.1+dune/opam
@@ -3,7 +3,7 @@ maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
 authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
 homepage: "http://erratique.ch/software/jsonm"
 doc: "http://erratique.ch/software/jsonm/doc/Jsonm"
-dev-repo: "git+https://github.com/dune-universe/jsonm.git"
+dev-repo: "git+https://github.com/dune-universe/jsonm.git#duniverse-v1.0.1"
 bug-reports: "https://github.com/dbuenzli/jsonm/issues"
 tags: [ "json" "codec" "org:erratique" ]
 license: "ISC"

--- a/packages/logs/logs.0.7.0+dune/opam
+++ b/packages/logs/logs.0.7.0+dune/opam
@@ -46,7 +46,7 @@ Logs and its reporters are distributed under the ISC license.
 """
 
 build: [[ "dune" "build" "-p" name ]]
-dev-repo: "git+https://github.com/dune-universe/logs.git"
+dev-repo: "git+https://github.com/dune-universe/logs.git#duniverse-v0.7.0"
 url {
   src: "https://github.com/dune-universe/logs/archive/v0.7.0+dune.tar.gz"
   checksum: "sha256=06ab994e5fc195f9b655544bffdc7d6aecec8f0f9b285e46f5668ec78030d13c"

--- a/packages/menhir/menhir.20200624+dune/opam
+++ b/packages/menhir/menhir.20200624+dune/opam
@@ -14,7 +14,7 @@ depends: [
   "menhirSdk" {= version}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]
-dev-repo: "git+https://github.com/dune-universe/menhir.git"
+dev-repo: "git+https://github.com/dune-universe/menhir.git#duniverse-menhir.20200624"
 url {
   src: "https://github.com/dune-universe/menhir/archive/v20200624+dune.tar.gz"
   checksum: "sha256=a85fcee494adb8f17a4de44ed4079c501adec6b5a33ce791c92f8e5d2481e40a"

--- a/packages/menhirLib/menhirLib.20200624+dune/opam
+++ b/packages/menhirLib/menhirLib.20200624+dune/opam
@@ -17,7 +17,7 @@ conflicts: [
   "menhir" {!= version}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]
-dev-repo: "git+https://github.com/dune-universe/menhir.git"
+dev-repo: "git+https://github.com/dune-universe/menhir.git#duniverse-menhir.20200624"
 url {
   src: "https://github.com/dune-universe/menhir/archive/v20200624+dune.tar.gz"
   checksum: "sha256=a85fcee494adb8f17a4de44ed4079c501adec6b5a33ce791c92f8e5d2481e40a"

--- a/packages/menhirSdk/menhirSdk.20200624+dune/opam
+++ b/packages/menhirSdk/menhirSdk.20200624+dune/opam
@@ -17,7 +17,7 @@ conflicts: [
   "menhir" {!= version}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]
-dev-repo: "git+https://github.com/dune-universe/menhir.git"
+dev-repo: "git+https://github.com/dune-universe/menhir.git#duniverse-menhir.20200624"
 url {
   src: "https://github.com/dune-universe/menhir/archive/v20200624+dune.tar.gz"
   checksum: "sha256=a85fcee494adb8f17a4de44ed4079c501adec6b5a33ce791c92f8e5d2481e40a"

--- a/packages/merlin/merlin.3.3.4+dune/opam
+++ b/packages/merlin/merlin.3.3.4+dune/opam
@@ -3,7 +3,7 @@ maintainer:   "defree@gmail.com"
 authors:      "The Merlin team"
 homepage:     "https://github.com/ocaml/merlin"
 bug-reports:  "https://github.com/ocaml/merlin/issues"
-dev-repo: "git+https://github.com/ocaml/merlin.git"
+dev-repo: "git+https://github.com/ocaml/merlin.git#duniverse-v3.3.4"
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/mtime/mtime.1.2.0+dune/opam
+++ b/packages/mtime/mtime.1.2.0+dune/opam
@@ -3,7 +3,7 @@ maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
 authors: [ "Daniel Bünzli <daniel.buenzl i@erratique.ch>" ]
 homepage: "http://erratique.ch/software/mtime"
 doc: "http://erratique.ch/software/mtime"
-dev-repo: "git+https://github.com/dune-universe/mtime.git"
+dev-repo: "git+https://github.com/dune-universe/mtime.git#duniverse-v1.2.0"
 bug-reports: "https://github.com/dbuenzli/mtime/issues"
 tags: [ "time" "monotonic" "system" "org:erratique" ]
 license: "ISC"

--- a/packages/num/num.1.3+dune/opam
+++ b/packages/num/num.1.3+dune/opam
@@ -8,7 +8,7 @@ authors: [
 license: "LGPL 2.1 with OCaml linking exception"
 homepage: "https://github.com/ocaml/num/"
 bug-reports: "https://github.com/ocaml/num/issues"
-dev-repo: "git+https://github.com/dune-universe/num.git"
+dev-repo: "git+https://github.com/dune-universe/num.git#duniverse-v1.3"
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/ocamlfind/ocamlfind.1.8.1+dune/opam
+++ b/packages/ocamlfind/ocamlfind.1.8.1+dune/opam
@@ -2,7 +2,7 @@ opam-version: "2.0"
 maintainer:   "Thomas Gazagnaire <thomas@gazagnaire.org>"
 homepage:     "http://projects.camlcity.org/projects/findlib.html"
 bug-reports:  "https://gitlab.camlcity.org/gerd/lib-findlib/issues"
-dev-repo: "git+https://github.com/dune-universe/lib-findlib.git"
+dev-repo: "git+https://github.com/dune-universe/lib-findlib.git#duniverse-1.8.1"
 build: [
   [ "env" "FINDLIB_PREFIX=%{lib}%" "dune" "build" "-p" name "-j" jobs ]
 ]

--- a/packages/ocamlgraph/ocamlgraph.1.8.8+dune/opam
+++ b/packages/ocamlgraph/ocamlgraph.1.8.8+dune/opam
@@ -8,7 +8,7 @@ authors: [
 homepage: "http://ocamlgraph.lri.fr/"
 license: "GNU Library General Public License version 2.1"
 doc: ["http://ocamlgraph.lri.fr/doc"]
-dev-repo: "git+https://github.com/dune-universe/ocamlgraph.git"
+dev-repo: "git+https://github.com/dune-universe/ocamlgraph.git#duniverse-v1.8.8"
 bug-reports: "https://github.com/backtracking/ocamlgraph/issues"
 
 tags: [

--- a/packages/opam-client/opam-client.2.0.7+dune/opam
+++ b/packages/opam-client/opam-client.2.0.7+dune/opam
@@ -26,7 +26,7 @@ build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
   [make "%{name}%.install"]
 ]
-dev-repo: "git+https://github.com/dune-universe/opam.git"
+dev-repo: "git+https://github.com/dune-universe/opam.git#duniverse-v2.0.7"
 url {
   src: "https://github.com/dune-universe/opam/archive/v2.0.7+dune.tar.gz"
   checksum: "sha256=80aaf6a16ebbab418e9e4016078fe9211870bd844fcbcfc3f7e05f5578de3c74"

--- a/packages/opam-core/opam-core.2.0.7+dune/opam
+++ b/packages/opam-core/opam-core.2.0.7+dune/opam
@@ -28,7 +28,7 @@ build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
   [make "%{name}%.install"]
 ]
-dev-repo: "git+https://github.com/dune-universe/opam.git"
+dev-repo: "git+https://github.com/dune-universe/opam.git#duniverse-v2.0.7"
 url {
   src: "https://github.com/dune-universe/opam/archive/v2.0.7+dune.tar.gz"
   checksum: "sha256=80aaf6a16ebbab418e9e4016078fe9211870bd844fcbcfc3f7e05f5578de3c74"

--- a/packages/opam-devel/opam-devel.2.0.7+dune/opam
+++ b/packages/opam-devel/opam-devel.2.0.7+dune/opam
@@ -33,7 +33,7 @@ The development version of opam has been successfully compiled into %{lib}%/%{na
 If you just want to give it a try without altering your current installation, you could use instead:
     alias opam2="OPAMROOT=~/.opam2 %{lib}%/%{name}%/opam\""""
     {success}
-dev-repo: "git+https://github.com/dune-universe/opam.git"
+dev-repo: "git+https://github.com/dune-universe/opam.git#duniverse-v2.0.7"
 url {
   src: "https://github.com/dune-universe/opam/archive/v2.0.7+dune.tar.gz"
   checksum: "sha256=80aaf6a16ebbab418e9e4016078fe9211870bd844fcbcfc3f7e05f5578de3c74"

--- a/packages/opam-format/opam-format.2.0.7+dune/opam
+++ b/packages/opam-format/opam-format.2.0.7+dune/opam
@@ -24,7 +24,7 @@ build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
   [make "%{name}%.install"]
 ]
-dev-repo: "git+https://github.com/dune-universe/opam.git"
+dev-repo: "git+https://github.com/dune-universe/opam.git#duniverse-v2.0.7"
 url {
   src: "https://github.com/dune-universe/opam/archive/v2.0.7+dune.tar.gz"
   checksum: "sha256=80aaf6a16ebbab418e9e4016078fe9211870bd844fcbcfc3f7e05f5578de3c74"

--- a/packages/opam-installer/opam-installer.2.0.7+dune/opam
+++ b/packages/opam-installer/opam-installer.2.0.7+dune/opam
@@ -24,7 +24,7 @@ build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
   [make "%{name}%.install"]
 ]
-dev-repo: "git+https://github.com/dune-universe/opam.git"
+dev-repo: "git+https://github.com/dune-universe/opam.git#duniverse-v2.0.7"
 url {
   src: "https://github.com/dune-universe/opam/archive/v2.0.7+dune.tar.gz"
   checksum: "sha256=80aaf6a16ebbab418e9e4016078fe9211870bd844fcbcfc3f7e05f5578de3c74"

--- a/packages/opam-repository/opam-repository.2.0.7+dune/opam
+++ b/packages/opam-repository/opam-repository.2.0.7+dune/opam
@@ -23,7 +23,7 @@ build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
   [make "%{name}%.install"]
 ]
-dev-repo: "git+https://github.com/dune-universe/opam.git"
+dev-repo: "git+https://github.com/dune-universe/opam.git#duniverse-v2.0.7"
 url {
   src: "https://github.com/dune-universe/opam/archive/v2.0.7+dune.tar.gz"
   checksum: "sha256=80aaf6a16ebbab418e9e4016078fe9211870bd844fcbcfc3f7e05f5578de3c74"

--- a/packages/opam-solver/opam-solver.2.0.7+dune/opam
+++ b/packages/opam-solver/opam-solver.2.0.7+dune/opam
@@ -26,7 +26,7 @@ build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
   [make "%{name}%.install"]
 ]
-dev-repo: "git+https://github.com/dune-universe/opam.git"
+dev-repo: "git+https://github.com/dune-universe/opam.git#duniverse-v2.0.7"
 url {
   src: "https://github.com/dune-universe/opam/archive/v2.0.7+dune.tar.gz"
   checksum: "sha256=80aaf6a16ebbab418e9e4016078fe9211870bd844fcbcfc3f7e05f5578de3c74"

--- a/packages/opam-state/opam-state.2.0.7+dune/opam
+++ b/packages/opam-state/opam-state.2.0.7+dune/opam
@@ -23,7 +23,7 @@ build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
   [make "%{name}%.install"]
 ]
-dev-repo: "git+https://github.com/dune-universe/opam.git"
+dev-repo: "git+https://github.com/dune-universe/opam.git#duniverse-v2.0.7"
 url {
   src: "https://github.com/dune-universe/opam/archive/v2.0.7+dune.tar.gz"
   checksum: "sha256=80aaf6a16ebbab418e9e4016078fe9211870bd844fcbcfc3f7e05f5578de3c74"

--- a/packages/ppx_tools/ppx_tools.7.0+dune/opam
+++ b/packages/ppx_tools/ppx_tools.7.0+dune/opam
@@ -13,7 +13,7 @@ depends: [
 build: [
  [ "dune" "subst" ]
  [ "dune" "build" "-p" name "-j" jobs] ]
-dev-repo: "git://github.com/dune-universe/ppx_tools.git"
+dev-repo: "git://github.com/dune-universe/ppx_tools.git#duniverse-master"
 synopsis: "Tools for authors of syntactic tools (such as ppx rewriters)"
 description: """
 The tools are installed as a findlib package called 'ppx_tools'.

--- a/packages/ptime/ptime.0.8.5+dune/opam
+++ b/packages/ptime/ptime.0.8.5+dune/opam
@@ -3,7 +3,7 @@ maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
 authors: ["The ptime programmers"]
 homepage: "http://erratique.ch/software/ptime"
 doc: "http://erratique.ch/software/ptime/doc"
-dev-repo: "git+https://github.com/dune-universe/ptime.git"
+dev-repo: "git+https://github.com/dune-universe/ptime.git#duniverse-v0.8.5"
 bug-reports: "https://github.com/dbuenzli/ptime/issues"
 tags: [ "time" "posix" "system" "org:erratique" ]
 license: "ISC"

--- a/packages/react/react.1.2.1+dune/opam
+++ b/packages/react/react.1.2.1+dune/opam
@@ -3,7 +3,7 @@ maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
 homepage: "http://erratique.ch/software/react"
 authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
 doc: "http://erratique.ch/software/react/doc/React"
-dev-repo: "git+https://github.com/dune-universe/react.git"
+dev-repo: "git+https://github.com/dune-universe/react.git#duniverse-v1.2.1"
 bug-reports: "https://github.com/dbuenzli/react/issues"
 tags: [ "reactive" "declarative" "signal" "event" "frp" "org:erratique" ]
 license: "ISC"

--- a/packages/rresult/rresult.0.6.0+dune/opam
+++ b/packages/rresult/rresult.0.6.0+dune/opam
@@ -3,7 +3,7 @@ maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
 authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
 homepage: "http://erratique.ch/software/rresult"
 doc: "http://erratique.ch/software/rresult"
-dev-repo: "git+https://github.com/dune-universe/rresult.git"
+dev-repo: "git+https://github.com/dune-universe/rresult.git#duniverse-v0.6.0"
 bug-reports: "https://github.com/dbuenzli/rresult/issues"
 tags: [ "result" "error" "declarative" "org:erratique" ]
 license: "ISC"

--- a/packages/textwrap/textwrap.0.2+dune/opam
+++ b/packages/textwrap/textwrap.0.2+dune/opam
@@ -3,7 +3,7 @@ maintainer: "Sergei Lebedev <superbobry@gmail.com>"
 authors: "Sergei Lebedev <superbobry@gmail.com>"
 homepage: "https://github.com/superbobry/ocaml-textwrap"
 bug-reports: "https://github.com/superbobry/ocaml-textwrap/issues"
-dev-repo: "git+https://github.com/dune-universe/ocaml-textwrap.git"
+dev-repo: "git+https://github.com/dune-universe/ocaml-textwrap.git#duniverse-v0.2"
 license: "MIT"
 depends: [
   "dune"

--- a/packages/topkg/topkg.1.0.1+dune/opam
+++ b/packages/topkg/topkg.1.0.1+dune/opam
@@ -4,7 +4,7 @@ authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
 homepage: "http://erratique.ch/software/topkg"
 doc: "http://erratique.ch/software/topkg/doc"
 license: "ISC"
-dev-repo: "git+https://github.com/dune-universe/topkg.git"
+dev-repo: "git+https://github.com/dune-universe/topkg.git#duniverse-v1.0.1"
 bug-reports: "https://github.com/dbuenzli/topkg/issues"
 depends: [
   "dune"

--- a/packages/uchar/uchar.0.0.2+dune/opam
+++ b/packages/uchar/uchar.0.0.2+dune/opam
@@ -3,7 +3,7 @@ maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
 authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
 homepage: "http://ocaml.org"
 doc: "https://ocaml.github.io/uchar/"
-dev-repo: "https://github.com/ocaml/uchar.git"
+dev-repo: "https://github.com/dune-universe/uchar.git#dune-universe-v0.0.2"
 bug-reports: "https://github.com/ocaml/uchar/issues"
 tags: [ "text" "character" "unicode" "compatibility" "org:ocaml.org" ]
 license: "typeof OCaml system"

--- a/packages/uucp/uucp.13.0.0+dune/opam
+++ b/packages/uucp/uucp.13.0.0+dune/opam
@@ -3,7 +3,7 @@ maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
 authors: [ "The uucp programmers" ]
 homepage: "https://erratique.ch/software/uucp"
 doc: "https://erratique.ch/software/uucp/doc/Uucp"
-dev-repo: "git+https://github.com/dune-universe/uucp.git"
+dev-repo: "git+https://github.com/dune-universe/uucp.git#duniverse-v13.0.0"
 bug-reports: "https://github.com/dbuenzli/uucp/issues"
 tags: [ "unicode" "text" "character" "org:erratique" ]
 license: "ISC"

--- a/packages/uuidm/uuidm.0.9.7+dune/opam
+++ b/packages/uuidm/uuidm.0.9.7+dune/opam
@@ -3,7 +3,7 @@ maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
 authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
 homepage: "http://erratique.ch/software/uuidm"
 doc: "http://erratique.ch/software/uuidm/doc/Uuidm"
-dev-repo: "git+https://github.com/dune-universe/uuidm.git"
+dev-repo: "git+https://github.com/dune-universe/uuidm.git#duniverse-v0.9.7"
 bug-reports: "https://github.com/dbuenzli/uuidm/issues"
 tags: [ "uuid" "codec" "org:erratique" ]
 license: "ISC"

--- a/packages/uuseg/uuseg.13.0.0+dune/opam
+++ b/packages/uuseg/uuseg.13.0.0+dune/opam
@@ -3,7 +3,7 @@ maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
 authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
 homepage: "https://erratique.ch/software/uuseg"
 doc: "https://erratique.ch/software/uuseg"
-dev-repo: "git+https://github.com/dune-universe/uuseg.git"
+dev-repo: "git+https://github.com/dune-universe/uuseg.git#duniverse-v13.0.0"
 bug-reports: "https://github.com/dbuenzli/uuseg/issues"
 tags: [ "segmentation" "text" "unicode" "org:erratique" ]
 license: "ISC"

--- a/packages/uutf/uutf.1.0.2+dune/opam
+++ b/packages/uutf/uutf.1.0.2+dune/opam
@@ -3,7 +3,7 @@ maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
 authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
 homepage: "http://erratique.ch/software/uutf"
 doc: "http://erratique.ch/software/uutf/doc/Uutf"
-dev-repo: "git+https://github.com/dune-universe/uutf.git"
+dev-repo: "git+https://github.com/dune-universe/uutf.git#duniverse-v1.0.2"
 bug-reports: "https://github.com/dbuenzli/uutf/issues"
 tags: [ "unicode" "text" "utf-8" "utf-16" "codec" "org:erratique" ]
 license: "ISC"

--- a/packages/webbrowser/webbrowser.0.6.1+dune/opam
+++ b/packages/webbrowser/webbrowser.0.6.1+dune/opam
@@ -4,7 +4,7 @@ authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
 homepage: "http://erratique.ch/software/webbrowser"
 doc: "http://erratique.ch/software/webbrowser/doc"
 license: "ISC"
-dev-repo: "git+https://github.com/dune-universe/webbrowser.git"
+dev-repo: "git+https://github.com/dune-universe/webbrowser.git#duniverse-v0.6.1"
 bug-reports: "https://github.com/dbuenzli/webbrowser/issues"
 tags: [ "web" "http" "uri" "browser" "cli" "org:erratique"]
 depends: [

--- a/packages/xmlm/xmlm.1.3.0+dune/opam
+++ b/packages/xmlm/xmlm.1.3.0+dune/opam
@@ -2,7 +2,7 @@ opam-version: "2.0"
 maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
 authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
 homepage: "http://erratique.ch/software/xmlm"
-dev-repo: "git+https://github.com/dune-universe/xmlm.git"
+dev-repo: "git+https://github.com/dune-universe/xmlm.git#duniverse-v1.3.0"
 bug-reports: "https://github.com/dbuenzli/xmlm/issues"
 doc: "http://erratique.ch/software/xmlm/doc/Xmlm"
 tags: [ "xml" "codec" "org:erratique" ]


### PR DESCRIPTION
Context: in my CI system (mirage-ci) I fetch dev-repos to build a "bleeding edge" monorepo. Specifying the correct branch in `dev-repo` fields allow me to fetch the dunified version of these packages.