### PR TITLE
[new release] zarith (1.12+dune)

### DIFF
--- a/packages/zarith/zarith.1.12+dune/opam
+++ b/packages/zarith/zarith.1.12+dune/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "Xavier Leroy <xavier.leroy@inria.fr>"
+authors: [
+  "Antoine Miné"
+  "Xavier Leroy"
+  "Pascal Cuoq"
+]
+homepage: "https://github.com/mirage/Zarith"
+bug-reports: "https://github.com/mirage/Zarith/issues"
+dev-repo: "git+https://github.com/mirage/Zarith.git"
+build: [
+  ["dune" "build" "-p" "zarith" ]
+]
+depends: [
+  "ocaml"     {>= "4.04.0"}
+  "dune"
+  ("gmp" | "conf-gmp" )
+]
+synopsis:
+  "Implements arithmetic and logical operations over arbitrary-precision integers"
+description: """
+The Zarith library implements arithmetic and logical operations over
+arbitrary-precision integers. It uses GMP to efficiently implement
+arithmetic over big integers. Small integers are represented as Caml
+unboxed integers, for speed and space economy."""
+url {
+  src:
+    "https://github.com/mirage/Zarith/releases/download/release-1.12%2Bdune/zarith-release-1.12.dune.tbz"
+  checksum: [
+    "sha256=d3ba741bcba41e840c26565b7e71c35b1194165dafa0064b0d72b123ba068c41"
+    "sha512=1d50ced87218dd020d3f0a8f74595b7e677f47292634df734553ca2783fafdba3fb11c13c5849a674cb53e5aef9a4fff4201a47340315855f6d4493acf42d6c3"
+  ]
+}
+x-commit-hash: "ab890eed75dbefa6e49667619804a1a0b8d71069"


### PR DESCRIPTION
This version of Zarith comes from: mirage/Zarith#1. You can see the global diff and I just made the tarball. This version will help us to definitely remove our `mirage-dev` overlays (regardless `base` which is the last piece required to fully cross-compile an unikernel).

The patch allows us to:
- Install `zarith` as a simple OPAM package with `conf-gmp` or `gmp` (see [mirage/ocaml-gmp])(https://github.com/mirage/ocaml-gmp)
- Use `zarith` as a package with `opam monorepo`
- Let `zarith` to take the host's `libgmp.a` (given by the virtual package `conf-gmp`) or the `gmp` (pulled by `opam monorepo` or installed via `opam`)

The last point allows to us to _cross-compile_ `zarith` with a cross-compiled version of `gmp`. Then, the final required point specific to MirageOS 4.0 is the deletion of `-g` which leads some relocations errors with some symbols.

Note that even if we are aware about the pending support of `dune` on `zarith` _upstream_, we can not delay the release of MirageOS 4.0 from this point.

/cc @hannesm, @samoht and @Leonidas-from-XIV 