### PR TITLE
[new release] mtime (1.3.0+dune)

### DIFF
--- a/packages/mtime/mtime.1.3.0+dune/opam
+++ b/packages/mtime/mtime.1.3.0+dune/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: """Monotonic wall-clock time for OCaml"""
+maintainer: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+authors: ["The mtime programmers"]
+homepage: "https://github.com/dune-universe/mtime"
+dev-repo: "git+https://github.com/dune-universe/mtime.git"
+bug-reports: "https://github.com/dbuenzli/mtime/issues"
+license: ["ISC"]
+tags: ["time" "monotonic" "system" "org:erratique"]
+depends: [
+  "dune"
+  "ocaml" {>= "4.03.0"}
+]
+depopts: ["js_of_ocaml"]
+conflicts: ["js_of_ocaml" {<= "3.3.0"}]
+build: [[ "dune" "build" "-p" name ]]
+description: """
+Mtime has platform independent support for monotonic wall-clock time
+in pure OCaml. This time increases monotonically and is not subject to
+operating system calendar time adjustments. The library has types to
+represent nanosecond precision timestamps and time spans.
+
+The additional Mtime_clock library provide access to a system
+monotonic clock.
+
+Mtime has a no dependency. Mtime_clock depends on your system library.
+The optional JavaScript support depends on [js_of_ocaml][jsoo]. Mtime
+and its libraries are distributed under the ISC license.
+
+[jsoo]: http://ocsigen.org/js_of_ocaml/
+
+Home page: http://erratique.ch/software/mtime"""
+url {
+  src:
+    "https://github.com/dune-universe/mtime/releases/download/v1.3.0%2Bdune/mtime-1.3.0.dune.tbz"
+  checksum: [
+    "sha256=0af606a71ea6bc43586ee0c9098bce54ecea49f73f0df9d451a6abf207761c50"
+    "sha512=20d3c3ca1f8620752d99aed24bbab3299889165e69746b67cea742d477ac894e5f5539ff5fc34697ac588f59a7d380372f723d97d16d8655b5351a46264b0ab9"
+  ]
+}
+x-commit-hash: "e7767e0429f82e8ca4a11aa409836d2fa503e942"


### PR DESCRIPTION
Monotonic wall-clock time for OCaml

- Project page: <a href="https://github.com/dune-universe/mtime">https://github.com/dune-universe/mtime</a>

##### CHANGES:

* Add Windows support. Thanks to Andreas Hauptmann for the patch
  and Corentin Leruth for the integration.
