### PR TITLE
[new release] uucp (14.0.0+dune)

### DIFF
--- a/packages/uucp/uucp.14.0.0+dune/opam
+++ b/packages/uucp/uucp.14.0.0+dune/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: """Unicode character properties for OCaml"""
+maintainer: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+authors: ["The uucp programmers"]
+homepage: "https://github.com/dune-universe/uucp"
+dev-repo: "git+https://github.com/dune-universe/uucp.git"
+bug-reports: "https://github.com/dbuenzli/uucp/issues"
+tags: [ "unicode" "text" "character" "org:erratique" ]
+license: "ISC"
+depends: [
+ "uchar"
+ "ocaml" {>= "4.03.0"}
+ "dune" {>="1.3"}
+ ]
+conflicts: [ "uutf" {< "1.0.1"}
+             "cmdliner" {< "1.0.0"} ]
+build: [
+ [ "dune" "subst" ] {pinned}
+ [ "dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src:
+    "https://github.com/dune-universe/uucp/releases/download/v14.0.0%2Bdune/uucp-14.0.0.dune.tbz"
+  checksum: [
+    "sha256=f94ce15a4d8b2bc1027fe2ddb840f873ac71095087ef117687ca060e1e61744a"
+    "sha512=537821fae464a843a8508732292f677fb514fc1143164494f05fb39cdeb72c643438e0703fca2b6e107fd33c27d6f68c5f69f46d633b7a24e27ca60f5b089468"
+  ]
+}
+x-commit-hash: "4f3f1dd0ff2677673718332c2b7eda5f32587841"


### PR DESCRIPTION
Unicode character properties for OCaml

- Project page: <a href="https://github.com/dune-universe/uucp">https://github.com/dune-universe/uucp</a>

##### CHANGES:

- Unicode 14.0.0 support.
- Tweak `Uucp.Break.tty_width_hint` (09d2186). Thanks to David Kaloper
  Meršinjak.
