### PR TITLE
[new release] uutf (1.0.3+dune)

### DIFF
--- a/packages/uutf/uutf.1.0.3+dune/opam
+++ b/packages/uutf/uutf.1.0.3+dune/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: """Non-blocking streaming Unicode codec for OCaml"""
+maintainer: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+authors: ["The uutf programmers"]
+homepage: "https://github.com/dune-universe/uutf"
+dev-repo: "git+https://github.com/dune-universe/uutf.git"
+bug-reports: "https://github.com/dbuenzli/uutf/issues"
+license: ["ISC"]
+tags: ["unicode" "text" "utf-8" "utf-16" "codec" "org:erratique"]
+depends: [
+  "dune"
+  "ocaml" {>= "4.03.0"}
+]
+depopts: ["cmdliner"]
+conflicts: ["cmdliner" {< "0.9.8"}]
+build: [[ "dune" "build" "-p" name ]]
+description: """
+Uutf is a non-blocking streaming codec to decode and encode the UTF-8,
+UTF-16, UTF-16LE and UTF-16BE encoding schemes. It can efficiently
+work character by character without blocking on IO. Decoders perform
+character position tracking and support newline normalization.
+
+Functions are also provided to fold over the characters of UTF encoded
+OCaml string values and to directly encode characters in OCaml
+Buffer.t values. **Note** that since OCaml 4.14, that functionality
+can be found in the Stdlib and you are encouraged to migrate to.
+
+Uutf has no dependency and is distributed under the ISC license.
+
+Home page: http://erratique.ch/software/uutf  
+Contact: Daniel Bünzli `<daniel.buenzl i@erratique.ch>`"""
+url {
+  src:
+    "https://github.com/dune-universe/uutf/releases/download/v1.0.3%2Bdune/uutf-1.0.3.dune.tbz"
+  checksum: [
+    "sha256=a207104302c6025b32377e6b4f046a037c56e3de12ce7eacd44c2f31ce71649d"
+    "sha512=7f8904668a37f39a0a61d63539c0afb55d5127e57e0b4ea7ce944216d8d299e44b0f13972ad55f973c93a659ee0f97cf0f1421a7012a15be4c719ee9f9cd857d"
+  ]
+}
+x-commit-hash: "6944629f736150f4e5693bc5875228b2ee40bda2"


### PR DESCRIPTION
Non-blocking streaming Unicode codec for OCaml

- Project page: <a href="https://github.com/dune-universe/uutf">https://github.com/dune-universe/uutf</a>

##### CHANGES:

- Support for OCaml 5.00, thanks to Kate (@kit-ty-kate) for
  the patch.
