### PR TITLE
Set maximum version of ocamlgraph for dose3

### DIFF
--- a/packages/dose3/dose3.5.0.1+dune/opam
+++ b/packages/dose3/dose3.5.0.1+dune/opam
@@ -17,7 +17,7 @@ dev-repo: "git+https://github.com/dune-universe/dose3.git#duniverse-5.0.1"
 depends: [
   "dune"
   "ocaml"
-  "ocamlgraph" {>= "1.8.6"}
+  "ocamlgraph" {>= "1.8.6" & < "2.0.0"}
   "cudf" {>= "0.7"}
   "conf-perl" {build}
   ("extlib" {>= "1.7.0"} | "extlib-compat" {>= "1.7.0"})


### PR DESCRIPTION
I've been investigating getting a newer opam to install in the monorepo, and opam 2.1.2 requires dose3 that is `>5` and `<6`. We have that in the repo, no problem. Unfortunately, our dose3 port does not currently work, because it depends on ocamlgraph and ocamlgraph 2.0.0 added a change

```
The value `empty' is required but not provided
```

Hence we need to make sure our old dose3 version does not pick up ocamlgraph >= 2.0.0, hence this PR.