### PR TITLE
Add cmdliner.1.1.0+dune

### DIFF
--- a/packages/cmdliner/cmdliner.1.1.0+dune/opam
+++ b/packages/cmdliner/cmdliner.1.1.0+dune/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: """Declarative definition of command line interfaces for OCaml"""
+maintainer: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+authors: ["The cmdliner programmers"]
+homepage: "https://erratique.ch/software/cmdliner"
+doc: "https://erratique.ch/software/cmdliner/doc"
+dev-repo: "git+https://github.com/dune-universe/cmdliner.git"
+bug-reports: "https://github.com/dbuenzli/cmdliner/issues"
+license: ["ISC"]
+tags: ["cli" "system" "declarative" "org:erratique"]
+depends: [ "ocaml" {>= "4.08.0"} "dune" ]
+build: [ "dune" "build" "-p" name "-j" jobs "@install" ]
+description: """
+Cmdliner allows the declarative definition of command line interfaces
+for OCaml.
+
+It provides a simple and compositional mechanism to convert command
+line arguments to OCaml values and pass them to your functions. The
+module automatically handles syntax errors, help messages and UNIX man
+page generation. It supports programs with single or multiple commands
+and respects most of the [POSIX][1] and [GNU][2] conventions.
+
+Cmdliner has no dependencies and is distributed under the ISC license.
+
+[1]: http://pubs.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap12.html
+[2]: http://www.gnu.org/software/libc/manual/html_node/Argument-Syntax.html
+
+Home page: http://erratique.ch/software/cmdliner"""
+url {
+  src: "https://github.com/dinosaure/cmdliner/archive/refs/tags/v1.1.0+dune.tar.gz"
+  checksum: "sha256=eeeef621cadc96011b9089ea9c794196e858df61af9cedb020d2e5a2fedf95f7"
+}
+x-commit-hash: "b97cca0c420441cb67fd1b1da059b0c394ee46c8"


### PR DESCRIPTION
Assume that my tag `dinosaure#duniverse-v1.1.0` is copied into `dune-universe/cmdliner` (see dune-universe/cmdliner#1), this version seems to work.

PS: it's a bit difficult to propose a clean patch since I don't have the rights to propose a tag/PR in the dune-universe organization.