### PR TITLE
Switch URLs from `git://` to `git+https://` for github

### DIFF
--- a/packages/bheap/bheap.1.0.0+dune/opam
+++ b/packages/bheap/bheap.1.0.0+dune/opam
@@ -15,6 +15,6 @@ build: [
 dev-repo: "git+https://github.com/dune-universe/bheap.git#to-dune"
 url {
   src:
-    "git://github.com/dune-universe/bheap.git#to-dune"
+    "git+https://github.com/dune-universe/bheap.git#to-dune"
 }
 

--- a/packages/ppx_tools/ppx_tools.6.1+dev+dune/opam
+++ b/packages/ppx_tools/ppx_tools.6.1+dev+dune/opam
@@ -6,7 +6,7 @@ license: "MIT"
 tags: [ "syntax" ]
 homepage: "https://github.com/dune-universe/ppx_tools"
 bug-reports: "https://github.com/ocaml-ppx/ppx_tools/issues"
-dev-repo: "git://github.com/dune-universe/ppx_tools.git"
+dev-repo: "git+https://github.com/dune-universe/ppx_tools.git"
 build: ["dune" "build" "-p" name "-j" jobs
     "@runtest" {with-test}]
 depends: [


### PR DESCRIPTION
Github is turning off unencrypted git protocol which prevents us from running things like `ls-remote` using those URLs.
See: https://github.blog/2021-09-01-improving-git-protocol-security-github/

This works perfectly well over https though hence the rewriting of those URLs.