### PR TITLE
[new release] Cmdliner.1.1.0+dune

### DIFF
--- a/packages/cmdliner/cmdliner.1.1.0+dune/opam
+++ b/packages/cmdliner/cmdliner.1.1.0+dune/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+synopsis: """Declarative definition of command line interfaces for OCaml"""
+maintainer: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+authors: ["The cmdliner programmers"]
+homepage: "https://erratique.ch/software/cmdliner"
+doc: "https://erratique.ch/software/cmdliner/doc"
+dev-repo: "git+https://erratique.ch/repos/cmdliner.git"
+bug-reports: "https://github.com/dbuenzli/cmdliner/issues"
+license: ["ISC"]
+tags: ["cli" "system" "declarative" "org:erratique"]
+depends: ["ocaml" {>= "4.08.0"}
+          "dune" {>= "1.4"}]
+build: [[ "dune" "build" "-p" name ]]
+url {
+  src: "https://erratique.ch/software/cmdliner/releases/cmdliner-1.1.0.tbz"
+  checksum: "sha512=e2fad706829e7b8b50d1a510b59b87e44294252d8e8bdd9d6cb07f435d7c1c123f82353eedf29e9a4b7768da485516b89b62bf956234e90d7eae1bbaae2c9263"}
+description: """
+Cmdliner allows the declarative definition of command line interfaces
+for OCaml.
+
+It provides a simple and compositional mechanism to convert command
+line arguments to OCaml values and pass them to your functions. The
+module automatically handles syntax errors, help messages and UNIX man
+page generation. It supports programs with single or multiple commands
+and respects most of the [POSIX][1] and [GNU][2] conventions.
+
+Cmdliner has no dependencies and is distributed under the ISC license.
+
+[1]: http://pubs.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap12.html
+[2]: http://www.gnu.org/software/libc/manual/html_node/Argument-Syntax.html
+
+Home page: http://erratique.ch/software/cmdliner"""


### PR DESCRIPTION
The changes were absolutely minimal because cmdliner already comes with `dune` (1.4) files, so it was essentially just using it in the opam file.

Potentially we could drop the port itself and just ship a modified opam-file in opam-overlays. What do you think @NathanReb?