### PR TITLE
[new release] ocplib-json-typed 0.7.1+dune

### DIFF
--- a/packages/ocplib-json-typed/ocplib-json-typed.0.7.1+dune/opam
+++ b/packages/ocplib-json-typed/ocplib-json-typed.0.7.1+dune/opam
@@ -13,7 +13,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune" {build & >= "1.7"}
+  "dune" {>= "1.7"}
   "uri" {>= "1.9.0" }
 ]
 url {


### PR DESCRIPTION
I think it makes sense to have this here. There is a small issue that needs to be fixed to make ocplib-json-typed work, there is an upstream issue to improve for the next release (so we can stop carrying this fork in the future) and `ocplib-json-typed` is not released very often so it is not a fast-moving target.

Thanks to @gpetiot for the fix, I cherry-picked his solution onto our fork.

Closes #108