### PR TITLE
[new release] ctypes and ctypes-foreign (0.20.1+dune)

### DIFF
--- a/packages/ctypes-foreign/ctypes-foreign.0.20.1+dune/opam
+++ b/packages/ctypes-foreign/ctypes-foreign.0.20.1+dune/opam
@@ -1,0 +1,62 @@
+opam-version: "2.0"
+synopsis: "Dynamic access to foreign C libraries using Ctypes"
+description: """
+
+This installs the `ctypes-foreign` interface which
+uses `libffi` to provide dynamic access to foreign libraries."""
+maintainer: ["Jeremy Yallop <yallop@gmail.com>"]
+authors: ["Jeremy Yallop"]
+license: "MIT"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/dune-universe/ocaml-ctypes"
+bug-reports: "https://github.com/dune-universe/ocaml-ctypes/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.03.0"}
+  "ctypes" {= version}
+  "dune-configurator"
+  "conf-pkg-config"
+  "lwt" {with-test}
+  "ounit" {with-test}
+  "conf-ncurses" {with-test}
+  "stdlib-shims" {with-test}
+  "conf-fts" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/dune-universe/ocaml-ctypes.git"
+post-messages: "This package requires libffi on your system" {failure}
+depexts: [
+  ["libffi-dev"] {os-distribution = "debian"}
+  ["libffi-dev"] {os-distribution = "ubuntu"}
+  ["libffi"] {os = "macos" & os-distribution = "homebrew"}
+  ["libffi"] {os = "macos" & os-distribution = "macports"}
+  ["libffi-devel"] {os-distribution = "centos"}
+  ["libffi-devel"] {os-distribution = "oraclelinux"}
+  ["libffi"] {os = "win32" & os-distribution = "cygwinports"}
+  ["libffi-devel"] {os-distribution = "fedora"}
+  ["libffi-dev"] {os-distribution = "alpine"}
+  ["libffi-devel"] {os-family = "suse"}
+]
+url {
+  src:
+    "https://github.com/dune-universe/ocaml-ctypes/releases/download/0.20.1%2Bdune/ctypes-foreign-0.20.1.dune.tbz"
+  checksum: [
+    "sha256=ce0ed787b18da3155ce4cc8685d755140448d153924c546e50aa5b81e9af2379"
+    "sha512=d4e1e4fba9c99171a3f179e46f5ac45f4b080691dad064c85948b038241dd20b7aee5c67d8c493a0bf5d2c48b7ae560412d6e761bdd4fb4387b92ac0219b5e2f"
+  ]
+}
+x-commit-hash: "fcf035bc3d53310843e06371dbedda59e4b2b28b"

--- a/packages/ctypes/ctypes.0.20.1+dune/opam
+++ b/packages/ctypes/ctypes.0.20.1+dune/opam
@@ -1,0 +1,59 @@
+opam-version: "2.0"
+synopsis: "Combinators for binding to C libraries without writing any C"
+description: """
+
+ctypes is a library for binding to C libraries using pure OCaml. The primary
+aim is to make writing C extensions as straightforward as possible.
+The core of ctypes is a set of combinators for describing the structure of C
+types -- numeric types, arrays, pointers, structs, unions and functions. You
+can use these combinators to describe the types of the functions that you want
+to call, then bind directly to those functions -- all without writing or
+generating any C!
+
+To install the optional `ctypes.foreign` interface (which uses `libffi` to
+provide dynamic access to foreign libraries), you will need to also install
+the `ctypes-foreign` package.
+
+    opam install ctypes-foreign
+
+This will make the `ctypes-foreign` ocamlfind subpackage available."""
+maintainer: ["Jeremy Yallop <yallop@gmail.com>"]
+authors: ["Jeremy Yallop"]
+license: "MIT"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/dune-universe/ocaml-ctypes"
+bug-reports: "https://github.com/dune-universe/ocaml-ctypes/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.03.0"}
+  "integers"
+  "dune-configurator"
+  "bigarray-compat"
+  "ounit" {with-test}
+  "conf-fts" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/dune-universe/ocaml-ctypes.git"
+url {
+  src:
+    "https://github.com/dune-universe/ocaml-ctypes/releases/download/0.20.1%2Bdune/ctypes-foreign-0.20.1.dune.tbz"
+  checksum: [
+    "sha256=ce0ed787b18da3155ce4cc8685d755140448d153924c546e50aa5b81e9af2379"
+    "sha512=d4e1e4fba9c99171a3f179e46f5ac45f4b080691dad064c85948b038241dd20b7aee5c67d8c493a0bf5d2c48b7ae560412d6e761bdd4fb4387b92ac0219b5e2f"
+  ]
+}
+x-commit-hash: "fcf035bc3d53310843e06371dbedda59e4b2b28b"


### PR DESCRIPTION
Combinators for binding to C libraries without writing any C

- Project page: <a href="https://github.com/dune-universe/ocaml-ctypes">https://github.com/dune-universe/ocaml-ctypes</a>

##### CHANGES:

* Fix warning 9 [missing-record-field-pattern] in generated OCaml code
  https://github.com/ocamllabs/ocaml-ctypes/pull/700

Thanks to Antonin Décimo (@MisterDA) for contributing to this release.
