### PR TITLE
[new release] ctypes and ctypes-foreign (0.20.1+dune)

### DIFF
--- a/packages/ctypes-foreign/ctypes-foreign.0.20.1+dune/opam
+++ b/packages/ctypes-foreign/ctypes-foreign.0.20.1+dune/opam
@@ -1,0 +1,62 @@
+opam-version: "2.0"
+synopsis: "Dynamic access to foreign C libraries using Ctypes"
+description: """
+
+This installs the `ctypes-foreign` interface which
+uses `libffi` to provide dynamic access to foreign libraries."""
+maintainer: ["Jeremy Yallop <yallop@gmail.com>"]
+authors: ["Jeremy Yallop"]
+license: "MIT"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/dune-universe/ocaml-ctypes"
+bug-reports: "https://github.com/dune-universe/ocaml-ctypes/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.03.0"}
+  "ctypes" {= version}
+  "dune-configurator"
+  "conf-pkg-config"
+  "lwt" {with-test}
+  "ounit2" {with-test}
+  "conf-ncurses" {with-test}
+  "stdlib-shims" {with-test}
+  "conf-fts" {with-test & os != "win32"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/dune-universe/ocaml-ctypes.git"
+post-messages: "This package requires libffi on your system" {failure}
+depexts: [
+  ["libffi-dev"] {os-distribution = "debian"}
+  ["libffi-dev"] {os-distribution = "ubuntu"}
+  ["libffi"] {os = "macos" & os-distribution = "homebrew"}
+  ["libffi"] {os = "macos" & os-distribution = "macports"}
+  ["libffi-devel"] {os-distribution = "centos"}
+  ["libffi-devel"] {os-distribution = "oraclelinux"}
+  ["libffi"] {os = "win32" & os-distribution = "cygwinports"}
+  ["libffi-devel"] {os-distribution = "fedora"}
+  ["libffi-dev"] {os-distribution = "alpine"}
+  ["libffi-devel"] {os-family = "suse"}
+]
+url {
+  src:
+    "https://github.com/dune-universe/ocaml-ctypes/releases/download/0.20.1%2Bdune/ctypes-foreign-0.20.1.dune.tbz"
+  checksum: [
+    "sha256=fd4ecf06c1d90931408c26708c21b7eb07bf703fdf06a793431451b7a1e8676f"
+    "sha512=241f2cf9b4dc9d352c7b5d487667dbef0d7708d025d9ae0adaab7389975ed76b67ef923d8041e4d6e3ce895d904f68ddded7812d514e117c32c4aae5fd9b5e2a"
+  ]
+}
+x-commit-hash: "9ec9e8f1647f0d63d17e6126358d673e3fbd05cd"

--- a/packages/ctypes/ctypes.0.20.1+dune/opam
+++ b/packages/ctypes/ctypes.0.20.1+dune/opam
@@ -1,0 +1,60 @@
+opam-version: "2.0"
+synopsis: "Combinators for binding to C libraries without writing any C"
+description: """
+
+ctypes is a library for binding to C libraries using pure OCaml. The primary
+aim is to make writing C extensions as straightforward as possible.
+The core of ctypes is a set of combinators for describing the structure of C
+types -- numeric types, arrays, pointers, structs, unions and functions. You
+can use these combinators to describe the types of the functions that you want
+to call, then bind directly to those functions -- all without writing or
+generating any C!
+
+To install the optional `ctypes.foreign` interface (which uses `libffi` to
+provide dynamic access to foreign libraries), you will need to also install
+the `ctypes-foreign` package.
+
+    opam install ctypes-foreign
+
+This will make the `ctypes-foreign` ocamlfind subpackage available."""
+maintainer: ["Jeremy Yallop <yallop@gmail.com>"]
+authors: ["Jeremy Yallop"]
+license: "MIT"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/dune-universe/ocaml-ctypes"
+bug-reports: "https://github.com/dune-universe/ocaml-ctypes/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.03.0"}
+  "integers"
+  "dune-configurator"
+  "bigarray-compat"
+  "ounit2" {with-test}
+  "conf-fts" {with-test & os != "win32"}
+  "conf-pkg-config" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/dune-universe/ocaml-ctypes.git"
+url {
+  src:
+    "https://github.com/dune-universe/ocaml-ctypes/releases/download/0.20.1%2Bdune/ctypes-foreign-0.20.1.dune.tbz"
+  checksum: [
+    "sha256=fd4ecf06c1d90931408c26708c21b7eb07bf703fdf06a793431451b7a1e8676f"
+    "sha512=241f2cf9b4dc9d352c7b5d487667dbef0d7708d025d9ae0adaab7389975ed76b67ef923d8041e4d6e3ce895d904f68ddded7812d514e117c32c4aae5fd9b5e2a"
+  ]
+}
+x-commit-hash: "9ec9e8f1647f0d63d17e6126358d673e3fbd05cd"


### PR DESCRIPTION
Combinators for binding to C libraries without writing any C

- Project page: <a href="https://github.com/dune-universe/ocaml-ctypes">https://github.com/dune-universe/ocaml-ctypes</a>

##### CHANGES:

* Fix warning 9 [missing-record-field-pattern] in generated OCaml code
  https://github.com/ocamllabs/ocaml-ctypes/pull/700

Thanks to Antonin Décimo (@MisterDA) for contributing to this release.
