### PR TITLE
Add base-bytes for OCaml 5.0 support (bytes is not a dune builtin anymore since OCaml 5.0)

### DIFF
--- a/packages/base-bytes/base-bytes.base+dune/opam
+++ b/packages/base-bytes/base-bytes.base+dune/opam
@@ -1,0 +1,17 @@
+opam-version: "2.0"
+license: "MIT"
+synopsis: "Bytes library distributed with the OCaml compiler"
+maintainer: "Kate <kit.ty.kate@disroot.org>"
+authors: "Kate <kit.ty.kate@disroot.org>"
+homepage: "https://github.com/kit-ty-kate/bytes"
+bug-reports: "https://github.com/kit-ty-kate/bytes/issues"
+dev-repo: "git+https://github.com/kit-ty-kate/bytes"
+depends: [
+  "ocaml" {>= "4.02"}
+  "dune" {>= "1.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+url {
+  src: "https://github.com/kit-ty-kate/bytes/archive/v0.1.0.tar.gz"
+  checksum: "sha256=795b9bf545841714aaf0e517b62834a589937f65ad815ed4589ea56fa614d238"
+}


### PR DESCRIPTION
In opam-repository, `base-bytes` depends on ocamlfind which installs a dummy META file for the `bytes` package.
With OCaml 5.0 dune does not have any builtin packages anymore and thus relies on the META files given by ocamlfind for `bytes`.

However in mirage context ocamlfind is not installed, thus we need a dummy package providing `bytes` otherwise we are unable to compile any mirage projects in OCaml 5.0