### PR TITLE
Fix the package name to be `bytes`

### DIFF
--- a/packages/base-bytes/base-bytes.base+dune/opam
+++ b/packages/base-bytes/base-bytes.base+dune/opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "4.02"}
   "dune" {>= "1.0"}
 ]
-build: ["dune" "build" "-p" name "-j" jobs]
+build: ["dune" "build" "-p" "bytes" "-j" jobs]
 url {
   src: "https://github.com/kit-ty-kate/bytes/archive/v0.1.0.tar.gz"
   checksum: "sha256=795b9bf545841714aaf0e517b62834a589937f65ad815ed4589ea56fa614d238"


### PR DESCRIPTION
Fixed upstream https://github.com/kit-ty-kate/bytes/pull/1 and backported here.

Fixes https://github.com/tarides/opam-monorepo/issues/343