### PR TITLE
Restrict `base-bytes` to only be selected on OCaml >= 5.0

### DIFF
--- a/packages/base-bytes/base-bytes.base+dune/opam
+++ b/packages/base-bytes/base-bytes.base+dune/opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/kit-ty-kate/bytes"
 bug-reports: "https://github.com/kit-ty-kate/bytes/issues"
 dev-repo: "git+https://github.com/kit-ty-kate/bytes"
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "5.0"}
   "dune" {>= "1.0"}
 ]
 build: ["dune" "build" "-p" "bytes" "-j" jobs]


### PR DESCRIPTION
Reported by @avsm in https://github.com/dune-universe/opam-overlays/pull/175#issuecomment-1376678278, this makes sure the `base-bytes` polyfill is only picked on OCaml 5.0.

CC @kit-ty-kate.