### PR TITLE
Revert "Restrict `base-bytes` to only be selected on OCaml >= 5.0"

### DIFF
--- a/packages/base-bytes/base-bytes.base+dune/opam
+++ b/packages/base-bytes/base-bytes.base+dune/opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/kit-ty-kate/bytes"
 bug-reports: "https://github.com/kit-ty-kate/bytes/issues"
 dev-repo: "git+https://github.com/kit-ty-kate/bytes"
 depends: [
-  "ocaml" {>= "5.0"}
+  "ocaml" {>= "4.02"}
   "dune" {>= "1.0"}
 ]
 build: ["dune" "build" "-p" "bytes" "-j" jobs]


### PR DESCRIPTION
This reverts commit b2b5e7e56d1a30cdd24a04504b88e24d88cef101.

For unbreaking compiling MirageOS unikernels.