### PR TITLE
[new release] ptime (1.1.0+dune)

### DIFF
--- a/packages/ptime/ptime.1.1.0+dune/opam
+++ b/packages/ptime/ptime.1.1.0+dune/opam
@@ -1,0 +1,43 @@
+
+opam-version: "2.0"
+synopsis: "POSIX time for OCaml"
+description: """\
+Ptime has platform independent POSIX time support in pure OCaml. It
+provides a type to represent a well-defined range of POSIX timestamps
+with picosecond precision, conversion with date-time values,
+conversion with [RFC 3339 timestamps][rfc3339] and pretty printing to
+a human-readable, locale-independent representation.
+
+The additional Ptime_clock library provides access to a system POSIX
+clock and to the system's current time zone offset.
+
+Ptime is not a calendar library.
+
+Ptime has no dependency. Ptime_clock depends on your system library or
+JavaScript runtime system. Ptime and its libraries are distributed
+under the ISC license.
+
+[rfc3339]: http://tools.ietf.org/html/rfc3339
+
+Home page: <http://erratique.ch/software/ptime>"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["The ptime programmers"]
+license: "ISC"
+tags: ["time" "posix" "system" "org:erratique"]
+homepage: "https://github.com/dune-universe/ptime"
+bug-reports: "https://github.com/dbuenzli/ptime/issues"
+depends: [
+  "dune"
+  "ocaml" {>= "4.08.0"}
+]
+build: [ "dune" "build" "-p" name "-j" jobs "@install" "@runtest" {with-test} ]
+dev-repo: "git+https://github.com/dune-universe/ptime.git"
+url {
+  src:
+    "https://github.com/dune-universe/ptime/releases/download/v1.1.0%2Bdune/ptime-1.1.0.dune.tbz"
+  checksum: [
+    "sha256=9aa6645808ce539eeafe4eaf781d6d0ae5639c90592cee31d15cf9363acf9234"
+    "sha512=0d037fc8f11c25b407f5501bd614dbbadb83fd6dce2fff5c0eeae27a9cd616f69f399f0cb3a04a2b0588cf1866cb16d6d1ae599791509cb995a92d3ae33ad1a0"
+  ]
+}
+x-commit-hash: "311e8a72a0ae1304cfa0fe92068c0a67cfa222a1"


### PR DESCRIPTION
POSIX time for OCaml

- Project page: <a href="https://github.com/dune-universe/ptime">https://github.com/dune-universe/ptime</a>

##### CHANGES:

- `Ptime.of_rfc3339` timezone offset parsing. Be even more lenient
   in non-strict parsing mode: allow `hhmm` and `hh` timezone offsets.
   (strict is `hh:mm`). Allows to parse an even larger subset of
   ISO 8601 than RFC 3339 (dune-universe/ptime#31).
- Add `Ptime.{to,of}_year`. Less costly than extracting the first
  component of `Ptime.to_date_time`. Useful for example to find
  out which DST rules a timestamp is subjected to for rendering.
- Add `?tz_offset_s` optional argument to `Ptime.{of,to}_date` (dune-universe/ptime#32).
- Add `Ptime.weekday_num`. An integer is often more convenient
  than the enum value of `Ptime.weekday` (dune-universe/ptime#30).
- Add `Ptime.rfc3339_string_error` convenience function.
- Use the new `js_of_ocaml` META `ocamlfind` standard to link
  JavaScript stubs (dune-universe/ptime#28).
- No longer install interfaces in the `ptime.clock` package,
  this package is now empty.
