### PR TITLE
Add `post-message` about installing base-bytes into a switch

### DIFF
--- a/packages/base-bytes/base-bytes.base+dune/opam
+++ b/packages/base-bytes/base-bytes.base+dune/opam
@@ -16,5 +16,5 @@ url {
   checksum: "sha256=795b9bf545841714aaf0e517b62834a589937f65ad815ed4589ea56fa614d238"
 }
 post-messages: [
-  "Do not install base-bytes.opam into an opam switch, it will not result in a working bytes library. This package is purely meant to be used with opam-monorepo."
+  "Do not install `base-bytes.opam` into an OPAM switch, it will not result in a working `bytes` library. This package is purely meant to be used with opam-monorepo. Use `opam install base-bytes.base` to install the right package in an OPAM switch."
 ]

--- a/packages/base-bytes/base-bytes.base+dune/opam
+++ b/packages/base-bytes/base-bytes.base+dune/opam
@@ -1,6 +1,16 @@
 opam-version: "2.0"
 license: "MIT"
 synopsis: "Bytes library distributed with the OCaml compiler"
+description: """
+Empty library to fulfill the `bytes` dependency in Dune builds. `bytes` is not
+necessary to get access to `Bytes` since OCaml 4.02 and that is the lowest
+version Dune supports but starting with OCaml 5 the library doesn't exist as
+part of the compiler anymore so such builds would fail.
+
+A proper solution is to remove `bytes` from the `(libraries)` stanza in Dune,
+but in the meantime this package provides a stop-gap solution to make these
+builds succeed (while not pulling in a findlib dependency).
+"""
 maintainer: "Kate <kit.ty.kate@disroot.org>"
 authors: "Kate <kit.ty.kate@disroot.org>"
 homepage: "https://github.com/kit-ty-kate/bytes"

--- a/packages/base-bytes/base-bytes.base+dune/opam
+++ b/packages/base-bytes/base-bytes.base+dune/opam
@@ -15,3 +15,6 @@ url {
   src: "https://github.com/kit-ty-kate/bytes/archive/v0.1.0.tar.gz"
   checksum: "sha256=795b9bf545841714aaf0e517b62834a589937f65ad815ed4589ea56fa614d238"
 }
+post-messages: [
+  "Do not install base-bytes.opam into an opam switch, it will not result in a working bytes library. This package is purely meant to be used with opam-monorepo."
+]


### PR DESCRIPTION
As reported by @samoht.