### PR TITLE
[new release] uucp (15.1.0+dune)

### DIFF
--- a/packages/uucp/uucp.15.1.0+dune/opam
+++ b/packages/uucp/uucp.15.1.0+dune/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Unicode character properties for OCaml"
+description: """\
+Uucp is an OCaml library providing efficient access to a selection of
+character properties of the [Unicode character database].
+
+Uucp is distributed under the ISC license. It has no dependency.
+
+Home page: <http://erratique.ch/software/uucp>
+
+[Unicode character database]: http://www.unicode.org/reports/tr44/"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The uucp programmers"
+license: "ISC"
+tags: ["unicode" "text" "character" "org:erratique"]
+homepage: "https://github.com/dune-universe/uucp"
+bug-reports: "https://github.com/dbuenzli/uucp/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "dune" {>= "1.1"}
+]
+depopts: ["uunf" "cmdliner"]
+conflicts: [
+  "uunf" {< "15.1.0" | >= "16.0.0"}
+  "cmdliner" {< "1.1.0"}
+]
+build: [ "dune" "build" "-p" name "-j" jobs "@install" ]
+dev-repo: "git+https://github.com/dune-universe/uucp.git"
+url {
+  src:
+    "https://github.com/dune-universe/uucp/releases/download/v15.1.0%2Bdune/uucp-15.1.0.dune.tbz"
+  checksum: [
+    "sha256=bd14c6e9e4a5e41d2f926c1311aa50034474911a82c37fdea0f062d281162223"
+    "sha512=47c514a52412f5f5b66e359c5f72b43c590670916d1e54a1048b52f22adb7183d3b993dc732a300c93bf3ff5936ef36f1cde6f80b605ac79092c6b03c958e588"
+  ]
+}
+x-commit-hash: "80323aef3b4a56fce8b8bd61e3f15e98ef8a59f4"


### PR DESCRIPTION
Unicode character properties for OCaml

- Project page: <a href="https://github.com/dune-universe/uucp">https://github.com/dune-universe/uucp</a>

##### CHANGES:

- Unicode 15.1.0 support.
- Require OCaml 4.14.0.
- Use module aliases for the property modules. Only pay for the
  modules you use (dune-universe/uucp#2).
- Use the standard library UTF decoders in the sample code and in
  `ucharinfo` (dune-universe/uucp#23).
- The `Num.numeric_value` had to be changed to accomodate for the
  data. It now returns either NaN or a list of numbers. This is due to
  the interpretation of U+5146 and U+79ED which is locale dependent
  and thus can represent multiple values. In all other cases you
  should get singelton lists so far.
- Rename `Uucd.Cjk.ids_bin_op` to `Uucd.Cjk.ids_binary_operator`.
- Rename `Uucd.Cjk.ids_tri_op` to `Uccd.Cjk.ids_trinary_operator`.
- Add `Uucd.Cjk.ids_unary_operator`, support for the new `IDS_Unary_Operator`
  property.
- Add `Uucd.Id.is_id_compat_math_{start,continue}`, support for the new
  `ID_Compat_Math_{Start,Continue}` properties.
- Add `Uucd.Case.Nfkc_simple_fold.fold`, support for the new
  `NFKC_Simple_Casefold` property.
- Add `Uucd.Break.indic_conjunct_break`, support for the new
  `Indic_Conjunct_Break` property.
