### PR TITLE
[new release] uuseg (15.1.0+dune)

### DIFF
--- a/packages/uuseg/uuseg.15.1.0+dune/opam
+++ b/packages/uuseg/uuseg.15.1.0+dune/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Unicode text segmentation for OCaml"
+description: """\
+Uuseg is an OCaml library for segmenting Unicode text. It implements
+the locale independent [Unicode text segmentation algorithms][1] to
+detect grapheme cluster, word and sentence boundaries and the [Unicode
+line breaking algorithm][2] to detect line break opportunities.
+
+The library is independent from any IO mechanism or Unicode text data
+structure and it can process text without a complete in-memory
+representation.
+
+Uuseg is distributed under the ISC license. It depends on [Uucp].
+
+[1]: http://www.unicode.org/reports/tr29/
+[2]: http://www.unicode.org/reports/tr14/
+[Uucp]: http://erratique.ch/software/uucp
+
+Homepage: <http://erratique.ch/software/uuseg>"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The uuseg programmers"
+license: "ISC"
+tags: ["unicode" "text" "segmentation" "org:erratique"]
+homepage: "https://github.com/dune-universe/uuseg"
+bug-reports: "https://github.com/dbuenzli/uucp/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "dune" {>= "1.10"}
+  "uucp" {>= "15.1.0" & < "16.0.0"}
+]
+depopts: ["uutf" "cmdliner"]
+conflicts: [
+  "uutf" {< "1.0.0"}
+  "cmdliner" {< "1.1.0"}
+]
+build: [ "dune" "build" "-p" name "-j" jobs ]
+dev-repo: "git+https://github.com/dune-universe/uuseg.git"
+url {
+  src:
+    "https://github.com/dune-universe/uuseg/releases/download/v15.1.0%2Bdune/uuseg-15.1.0.dune.tbz"
+  checksum: [
+    "sha256=d8c2f9c841c32de832182eac8345699823ef6d57c58278c51fbb7c98ab3f2aa8"
+    "sha512=9234277c02e94c254d6d0ab866c653b7b5f94e3682aa3571d0c3c450d53b0e1f2a30699e956c2ee5aec1e0a759d4a2b465bef4a2184b97fbf4fd378ca4e377bb"
+  ]
+}
+x-commit-hash: "a9adc233ebd3d18d16a9058365075c7bd8a60977"


### PR DESCRIPTION
Unicode text segmentation for OCaml

- Project page: <a href="https://github.com/dune-universe/uuseg">https://github.com/dune-universe/uuseg</a>

##### CHANGES:

- Unicode 15.1.0 support.
- Requires OCaml 4.14.0 for the UTF decoders.
- The `Uuseg_string` module was rewritten to use the standard library
  UTF decoders and was moved to the `uuseg` library. The `uuseg.string`
  library is deprecated, it warns on usage and simply requires `uuseg`.
- The sample code was rewritten to use the standard library UTF
  decoders.
