### PR TITLE
Add an overlay suffix for the colombe distribution

### DIFF
--- a/packages/colombe/colombe.0.8.0+overlay/opam
+++ b/packages/colombe/colombe.0.8.0+overlay/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+license:      "MIT"
+authors:      [ "Charles-Edouard Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+maintainer:   [ "Charles-Edouard Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://github.com/mirage/colombe"
+bug-reports:  "https://github.com/mirage/colombe/issues"
+dev-repo:     "git+https://github.com/mirage/colombe.git"
+synopsis:     "SMTP protocol in OCaml"
+doc:          "https://mirage.github.io/colombe/"
+description: """SMTP protocol according RFC5321 without extension."""
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "2.0.0"}
+  "fmt" {>= "0.8.9"}
+  "ipaddr" {>= "3.0.0"}
+  "angstrom" {>= "0.14.0"}
+  "ocaml-syntax-shims"
+  "alcotest" {with-test}
+  "crowbar" {>= "0.2" & with-test}
+]
+depopts: [ "emile" ]
+conflicts: [ "emile" {< "0.8"} ]
+url {
+  src:
+    "https://github.com/mirage/colombe/releases/download/received-v0.5.2/colombe-received-v0.5.2.tbz"
+  checksum: [
+    "sha256=069876ecac48c9069263fdb4fbd79a72e6b613b2a7be3cb77d2ea73bef2c2fbe"
+    "sha512=b0ce2329a1d91effcb98e88e7ad000afe20635f58e8d69eecab911233f3d689d9f498ac1f9c98c0d39577c30596e0cabae9bb0f750f707add1888581d779d76d"
+  ]
+}
+x-commit-hash: "cdd3ea41888df003020806213200c057eb43aa25"

--- a/packages/sendmail-lwt/sendmail-lwt.0.8.0+overlay/opam
+++ b/packages/sendmail-lwt/sendmail-lwt.0.8.0+overlay/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+license:      "MIT"
+authors:      [ "Charles-Edouard Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+maintainer:   [ "Charles-Edouard Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://github.com/mirage/colombe"
+bug-reports:  "https://github.com/mirage/colombe/issues"
+dev-repo:     "git+https://github.com/mirage/colombe.git"
+doc:          "https://mirage.github.io/colombe/"
+synopsis:     "Implementation of the sendmail command over LWT"
+description: """A library to be able to send an email with LWT and TLS."""
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "2.0"}
+  "sendmail" {= version}
+  "domain-name"
+  "lwt"
+  "tls" {>= "0.13.0"}
+  "tls-lwt" {>= "0.16.0"}
+  "x509" {>= "0.12.0"}
+  "alcotest" {with-test}
+]
+url {
+  src:
+    "https://github.com/mirage/colombe/releases/download/received-v0.5.2/colombe-received-v0.5.2.tbz"
+  checksum: [
+    "sha256=069876ecac48c9069263fdb4fbd79a72e6b613b2a7be3cb77d2ea73bef2c2fbe"
+    "sha512=b0ce2329a1d91effcb98e88e7ad000afe20635f58e8d69eecab911233f3d689d9f498ac1f9c98c0d39577c30596e0cabae9bb0f750f707add1888581d779d76d"
+  ]
+}
+x-commit-hash: "cdd3ea41888df003020806213200c057eb43aa25"

--- a/packages/sendmail/sendmail.0.8.0+overlay/opam
+++ b/packages/sendmail/sendmail.0.8.0+overlay/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+license:      "MIT"
+authors:      [ "Charles-Edouard Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+maintainer:   [ "Charles-Edouard Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://github.com/mirage/colombe"
+bug-reports:  "https://github.com/mirage/colombe/issues"
+dev-repo:     "git+https://github.com/mirage/colombe.git"
+doc:          "https://mirage.github.io/colombe/"
+synopsis:     "Implementation of the sendmail command"
+description: """A library to be able to send an email."""
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "2.0"}
+  "colombe" {= version}
+  "tls" {>= "0.13.0"}
+  "base64" {>= "3.0.0"}
+  "ke" {>= "0.4"}
+  "logs"
+  "rresult"
+  "bigstringaf" {>= "0.2.0"}
+  "emile" {>= "0.8" & with-test}
+  "mrmime" {>= "0.3.2" & with-test}
+  "cstruct" {>= "6.0.0"}
+  "alcotest" {with-test}
+]
+url {
+  src:
+    "https://github.com/mirage/colombe/releases/download/received-v0.5.2/colombe-received-v0.5.2.tbz"
+  checksum: [
+    "sha256=069876ecac48c9069263fdb4fbd79a72e6b613b2a7be3cb77d2ea73bef2c2fbe"
+    "sha512=b0ce2329a1d91effcb98e88e7ad000afe20635f58e8d69eecab911233f3d689d9f498ac1f9c98c0d39577c30596e0cabae9bb0f750f707add1888581d779d76d"
+  ]
+}
+x-commit-hash: "cdd3ea41888df003020806213200c057eb43aa25"


### PR DESCRIPTION
/cc @hannesm to fix the issue that `opam monorepo` should not pick the the same Git repository between `received` and `colombe` (they don't have the same release cycle).