### PR TITLE
Package the `lwt_ppx` 2.1.0 bundled with `lwt` 5.7.0

### DIFF
--- a/packages/lwt_ppx/lwt_ppx.2.1.0+lwt.5.7.0/opam
+++ b/packages/lwt_ppx/lwt_ppx.2.1.0+lwt.5.7.0/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+synopsis:
+  "PPX syntax for Lwt, providing something similar to async/await from JavaScript"
+maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+authors: "Gabriel Radanne"
+license: "MIT"
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt/dev/api/Ppx_lwt"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+depends: [
+  "dune" {>= "1.8.0"}
+  "lwt"
+  "ocaml" {>= "4.08"}
+  "ppxlib" {>= "0.16.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/ocsigen/lwt.git"
+url {
+  src: "https://github.com/ocsigen/lwt/archive/refs/tags/5.7.0.tar.gz"
+  checksum: [
+    "md5=737039d29d45b2d2b35db6931c8d75c6"
+    "sha512=42e629920783428673b99c9d7a639237c9e6b35079b5d907bc67e7ea506acf9edadc48cec580bdcfd2410ed9412bf5e6bcc8b09de2fa7d35ce1490973d05ddd1"
+  ]
+}


### PR DESCRIPTION
Add the `lwt_ppx` 2.1.0 bundled with `lwt` 5.7.0 so that `monorepo` can find a common revision for both packages that is compatible with OCaml 5.2.