### PR TITLE
[new release] uuseg (15.1.0+dune2)

### DIFF
--- a/packages/uuseg/uuseg.15.1.0+dune2/opam
+++ b/packages/uuseg/uuseg.15.1.0+dune2/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Unicode text segmentation for OCaml"
+description: """\
+Uuseg is an OCaml library for segmenting Unicode text. It implements
+the locale independent [Unicode text segmentation algorithms][1] to
+detect grapheme cluster, word and sentence boundaries and the [Unicode
+line breaking algorithm][2] to detect line break opportunities.
+
+The library is independent from any IO mechanism or Unicode text data
+structure and it can process text without a complete in-memory
+representation.
+
+Uuseg is distributed under the ISC license. It depends on [Uucp].
+
+[1]: http://www.unicode.org/reports/tr29/
+[2]: http://www.unicode.org/reports/tr14/
+[Uucp]: http://erratique.ch/software/uucp
+
+Homepage: <http://erratique.ch/software/uuseg>"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The uuseg programmers"
+license: "ISC"
+tags: ["unicode" "text" "segmentation" "org:erratique"]
+homepage: "https://github.com/dune-universe/uuseg"
+bug-reports: "https://github.com/dbuenzli/uucp/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "dune" {>= "1.10"}
+  "uucp" {>= "15.1.0" & < "16.0.0"}
+]
+depopts: ["uutf" "cmdliner"]
+conflicts: [
+  "uutf" {< "1.0.0"}
+  "cmdliner" {< "1.1.0"}
+]
+build: [ "dune" "build" "-p" name "-j" jobs ]
+dev-repo: "git+https://github.com/dune-universe/uuseg.git"
+url {
+  src:
+    "https://github.com/dune-universe/uuseg/releases/download/v15.1.0%2Bdune2/uuseg-15.1.0.dune2.tbz"
+  checksum: [
+    "sha256=3c7f26f26c85482c7b53d0008eb4a972f092a1898123187a1af20893c86ba137"
+    "sha512=94b8cdfe790d1cf0db6cb704b37868aa0d80416270decba185916cafb9768a8384550e3a376459c464152c34e0ae64277883f3a834818385726b1b6dbaf0b03f"
+  ]
+}
+x-commit-hash: "7883cbb2c0314b5cf70396c5ab3262dd1c1b0056"


### PR DESCRIPTION
Unicode text segmentation for OCaml

- Project page: <a href="https://github.com/dune-universe/uuseg">https://github.com/dune-universe/uuseg</a>

##### CHANGES:

- Unicode 15.1.0 support.
- Requires OCaml 4.14.0 for the UTF decoders.
- The `Uuseg_string` module was rewritten to use the standard library
  UTF decoders and was moved to the `uuseg` library. The `uuseg.string`
  library is deprecated, it warns on usage and simply requires `uuseg`.
- The sample code was rewritten to use the standard library UTF
  decoders.

Fixes #213 