### PR TITLE
[new release] logs (0.9.0+dune)

### DIFF
--- a/packages/logs/logs.0.9.0+dune/opam
+++ b/packages/logs/logs.0.9.0+dune/opam
@@ -1,0 +1,60 @@
+opam-version: "2.0"
+synopsis: "Logging infrastructure for OCaml"
+description: """\
+Logs provides a logging infrastructure for OCaml. Logging is performed
+on sources whose reporting level can be set independently. Log message
+report is decoupled from logging and is handled by a reporter.
+
+A few optional log reporters are distributed with the base library and
+the API easily allows to implement your own.
+
+`Logs` has no dependencies. The optional `Logs_fmt` reporter on OCaml
+formatters depends on [Fmt][fmt].  The optional `Logs_browser`
+reporter that reports to the web browser console depends on
+[js_of_ocaml][jsoo]. The optional `Logs_cli` library that provides
+command line support for controlling Logs depends on
+[`Cmdliner`][cmdliner]. The optional `Logs_lwt` library that provides
+Lwt logging functions depends on [`Lwt`][lwt]
+
+Logs and its reporters are distributed under the ISC license.
+
+[fmt]: http://erratique.ch/software/fmt
+[jsoo]: http://ocsigen.org/js_of_ocaml/
+[cmdliner]: http://erratique.ch/software/cmdliner
+[lwt]: http://ocsigen.org/lwt/
+
+Home page: <http://erratique.ch/software/logs>"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The logs programmers"
+license: "ISC"
+tags: ["log" "system" "org:erratique"]
+homepage: "https://erratique.ch/software/logs"
+doc: "https://erratique.ch/software/logs/doc"
+bug-reports: "https://github.com/dbuenzli/logs/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "lwt"
+  "fmt"
+  "cmdliner"
+  "dune"
+  "mtime" {with-test}
+]
+depopts: [
+  "js_of_ocaml"
+]
+conflicts: [
+  "cmdliner" {< "1.3.0"}
+  "js_of_ocaml-compiler" {< "5.5.0"}
+  "fmt" {< "0.9.0"}
+]
+build: [[ "dune" "build" "-p" name ]]
+dev-repo: "git+https://github.com/dune-universe/logs.git"
+url {
+  src:
+    "https://github.com/dune-universe/logs/releases/download/v0.9.0%2Bdune/logs-0.9.0.dune.tbz"
+  checksum: [
+    "sha256=f9100af533d45204bc5d27bddb2f6899b3b0748c535a1a6502c6ac3dce93825e"
+    "sha512=bb3dc1f220f6d5593a2918c4f3253799b1e5defa8f433023ec966344e3f2d3f65ee408689f65ee128aa1ffdd74f0d786320c79ba30c00e213e48ad128ca86744"
+  ]
+}
+x-commit-hash: "bdcd7d7b5df3c94d32957e383726f02765bdd2fc"


### PR DESCRIPTION
Logging infrastructure for OCaml

- Project page: <a href="https://erratique.ch/software/logs">https://erratique.ch/software/logs</a>
- Documentation: <a href="https://erratique.ch/software/logs/doc">https://erratique.ch/software/logs/doc</a>

##### CHANGES:

* Replace references and mutable fields by atomic references to avoid
  race conditions (dune-universe/logs#56). Thanks to Nathan Taylor for reporting.
* Fix `Logs.{err,warn}_count`. The counts were counting the reports
  not the logs which is not what the spec says. This means the counts
  were wrong when the reporting level was below the corresponding
  level (dune-universe/logs#55). Thanks to Mathieu Barbin for the report.
* Fix `Log.Tag.list` always returning the empty list.
* `Logs.format_reporter` and `Logs_fmt.reporter` replace a few format
  strings and `^^` uses by direct calls to `Format` primitives.
* Requires OCaml >= 4.14.
* Use Format.pp_print_text instead of your own.
* Export `logs` from each sub library.
