### PR TITLE
[new release] logs (0.9.0+dune2)

### DIFF
--- a/packages/logs/logs.0.9.0+dune2/opam
+++ b/packages/logs/logs.0.9.0+dune2/opam
@@ -1,0 +1,58 @@
+opam-version: "2.0"
+synopsis: "Logging infrastructure for OCaml"
+description: """\
+Logs provides a logging infrastructure for OCaml. Logging is performed
+on sources whose reporting level can be set independently. Log message
+report is decoupled from logging and is handled by a reporter.
+
+A few optional log reporters are distributed with the base library and
+the API easily allows to implement your own.
+
+`Logs` has no dependencies. The optional `Logs_fmt` reporter on OCaml
+formatters depends on [Fmt][fmt].  The optional `Logs_browser`
+reporter that reports to the web browser console depends on
+[js_of_ocaml][jsoo]. The optional `Logs_cli` library that provides
+command line support for controlling Logs depends on
+[`Cmdliner`][cmdliner]. The optional `Logs_lwt` library that provides
+Lwt logging functions depends on [`Lwt`][lwt]
+
+Logs and its reporters are distributed under the ISC license.
+
+[fmt]: http://erratique.ch/software/fmt
+[jsoo]: http://ocsigen.org/js_of_ocaml/
+[cmdliner]: http://erratique.ch/software/cmdliner
+[lwt]: http://ocsigen.org/lwt/
+
+Home page: <http://erratique.ch/software/logs>"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The logs programmers"
+license: "ISC"
+tags: ["log" "system" "org:erratique"]
+homepage: "https://erratique.ch/software/logs"
+doc: "https://erratique.ch/software/logs/doc"
+bug-reports: "https://github.com/dbuenzli/logs/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "lwt"
+  "fmt" {>= "0.9.0"}
+  "cmdliner" {>= "1.3.0"}
+  "dune"
+  "mtime" {with-test}
+]
+depopts: [
+  "js_of_ocaml"
+]
+conflicts: [
+  "js_of_ocaml-compiler" {< "5.5.0"}
+]
+build: [[ "dune" "build" "-p" name ]]
+dev-repo: "git+https://github.com/dune-universe/logs.git"
+url {
+  src:
+    "https://github.com/dune-universe/logs/releases/download/v0.9.0%2Bdune2/logs-0.9.0.dune2.tbz"
+  checksum: [
+    "sha256=7afc1c0c9c1214dbc58b4c463bbe1e3b1a6f4d2e72b1aa8a990b0566eaf5a8fa"
+    "sha512=d34a38671ed975d078551e2c3d926ceb7e84caaca3ff9781f6ef5faf60da45343f1376c80062cd3496880b57b2a5c5a700f58ab99a08accf58411077ad9d80ff"
+  ]
+}
+x-commit-hash: "278b511d21b127f125a76d18f65a99165445de92"


### PR DESCRIPTION
Logging infrastructure for OCaml

- Project page: <a href="https://erratique.ch/software/logs">https://erratique.ch/software/logs</a>
- Documentation: <a href="https://erratique.ch/software/logs/doc">https://erratique.ch/software/logs/doc</a>

##### CHANGES:

* Replace references and mutable fields by atomic references to avoid
  race conditions (dune-universe/logs#56). Thanks to Nathan Taylor for reporting.
* Fix `Logs.{err,warn}_count`. The counts were counting the reports
  not the logs which is not what the spec says. This means the counts
  were wrong when the reporting level was below the corresponding
  level (dune-universe/logs#55). Thanks to Mathieu Barbin for the report.
* Fix `Log.Tag.list` always returning the empty list.
* `Logs.format_reporter` and `Logs_fmt.reporter` replace a few format
  strings and `^^` uses by direct calls to `Format` primitives.
* Requires OCaml >= 4.14.
* Use Format.pp_print_text instead of your own.
* Export `logs` from each sub library.
