### PR TITLE
[new release] cmarkit (0.3.0+dune)

### DIFF
--- a/packages/cmarkit/cmarkit.0.3.0+dune/opam
+++ b/packages/cmarkit/cmarkit.0.3.0+dune/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "CommonMark parser and renderer for OCaml"
+description: """\
+Cmarkit parses the [CommonMark specification]. It provides:
+
+- A CommonMark parser for UTF-8 encoded documents. Link label resolution
+  can be customized and a non-strict parsing mode can be activated to add: 
+  strikethrough, LaTeX math, footnotes, task items and tables.
+  
+- An extensible abstract syntax tree for CommonMark documents with
+  source location tracking and best-effort source layout preservation.
+
+- Abstract syntax tree mapper and folder abstractions for quick and
+  concise tree transformations.
+  
+- Extensible renderers for HTML, LaTeX and CommonMark with source
+  layout preservation.
+
+Cmarkit is distributed under the ISC license. It has no dependencies.
+
+[CommonMark specification]: https://spec.commonmark.org/
+
+Homepage: <https://erratique.ch/software/cmarkit>"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The cmarkit programmers"
+license: "ISC"
+tags: ["codec" "commonmark" "markdown" "org:erratique"]
+homepage: "https://github.com/dune-universe/cmarkit"
+bug-reports: "https://github.com/dbuenzli/cmarkit/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "dune"
+]
+depopts: ["cmdliner"]
+conflicts: [
+  "cmdliner" {< "1.1.0"}
+]
+build: [ "dune" "build" "-p" name "-j" jobs ]
+dev-repo: "git+https://github.com/dune-universe/cmarkit.git"
+url {
+  src:
+    "https://github.com/dune-universe/cmarkit/releases/download/v0.3.0%2Bdune/cmarkit-0.3.0.dune.tbz"
+  checksum: [
+    "sha256=822dca2b7c97b31a430cf86534011f5ea38874d4fc2dd79e5272b25288f236f7"
+    "sha512=1d15bf8ea669c502e372f58517b2c418a577e6a6268ca3438165750de58aa35242a3dcdca09caf5b40c63aaedebbbd6b9d081fd231eb531ddcb84a7f8ab516ef"
+  ]
+}
+x-commit-hash: "8f0667a0ef17e98c8e3cea63d1aac7c44f38c3d2"


### PR DESCRIPTION
CommonMark parser and renderer for OCaml

- Project page: <a href="https://github.com/dune-universe/cmarkit">https://github.com/dune-universe/cmarkit</a>

##### CHANGES:

- Fix ordered item marker escaping. Thanks to Rafał Gwoździński for
  the report (dune-universe/cmarkit#11).

- Data updated for Unicode 15.1.0 (no changes except
  for the value of `Cmarkit.Doc.unicode_version`).

- Fix table extension column parsing, toplevel text inlines were being
  dropped. Thanks to Javier Chávarri for the report (dune-universe/cmarkit#10).

- `List_item.make`, change default value of `after_marker` from 0 to 1.
  We don't want to generate invalid CommonMark by default. Thanks to
  Rafał Gwoździński for the report (dune-universe/cmarkit#9).

- Add option `-f/--full-featured`, to `cmarkit html`. A synonym for a
  bunch of existing options to generate a publishable document with extensions
  and math rendering without hassle.  See `cmarkit html --help` for details.

