### PR TITLE
[new release] cmarkit (0.4.0+dune)

### DIFF
--- a/packages/cmarkit/cmarkit.0.4.0+dune/opam
+++ b/packages/cmarkit/cmarkit.0.4.0+dune/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "CommonMark parser and renderer for OCaml"
+description: """\
+Cmarkit parses the [CommonMark specification]. It provides:
+
+- A CommonMark parser for UTF-8 encoded documents. Link label resolution
+  can be customized and a non-strict parsing mode can be activated to add: 
+  strikethrough, LaTeX math, footnotes, task items and tables.
+  
+- An extensible abstract syntax tree for CommonMark documents with
+  source location tracking and best-effort source layout preservation.
+
+- Abstract syntax tree mapper and folder abstractions for quick and
+  concise tree transformations.
+  
+- Extensible renderers for HTML, LaTeX and CommonMark with source
+  layout preservation.
+
+Cmarkit is distributed under the ISC license. It has no dependencies.
+
+[CommonMark specification]: https://spec.commonmark.org/
+
+Homepage: <https://erratique.ch/software/cmarkit>"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The cmarkit programmers"
+license: "ISC"
+tags: ["codec" "commonmark" "markdown" "org:erratique"]
+homepage: "https://github.com/dune-universe/cmarkit"
+bug-reports: "https://github.com/dbuenzli/cmarkit/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "dune"
+]
+depopts: ["cmdliner"]
+conflicts: [
+  "cmdliner" {< "2.0.0"}
+]
+build: [ "dune" "build" "-p" name "-j" jobs ]
+dev-repo: "git+https://github.com/dune-universe/cmarkit.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/dune-universe/cmarkit/releases/download/v0.4.0%2Bdune/cmarkit-0.4.0.dune.tbz"
+  checksum: [
+    "sha256=b085c28336e9483689d3846241547646a263fb9d3907f4ebeb262aaa11783ee2"
+    "sha512=162b18312c5e7fac057bec0d7181657a1ad8d40ac6e7ca86f089e72f7e6470774db6a83e78f74b2f4d77465e8918fb76c9d0f28dc0721a0274e7b3df5078c02f"
+  ]
+}
+x-commit-hash: "a1411015d5fb39f0b7fa434f958e03bed6051882"


### PR DESCRIPTION
CommonMark parser and renderer for OCaml

- Project page: <a href="https://github.com/dune-universe/cmarkit">https://github.com/dune-universe/cmarkit</a>

##### CHANGES:

- Support for the CommonMark 0.31.2 specification (dune-universe/cmarkit#17).

- Change task items extension semantics: the task marker is no longer
  considered part of the list marker. The new semantics can lead to
  surprises with item subparagraphs which can show up as indented code
  blocks, but it avoids huge indentations for subtasks and is consistent
  with what at least GFM and `md4c` do.
  Thanks to Thomas Gazagnaire for the report (dune-universe/cmarkit#24).

- `Cmarkit_latex`. Add option `?first_heading_level` to the renderer
  to set the LaTeX heading level to use for the first CommonMark
  heading level. A corresponding option `--first-heading-level` is
  added to `cmarkit latex`.
  Thanks to Léo Andrès for the patch (dune-universe/cmarkit#16).

- `cmarkit html` command: add option `--body-id` to identify page body
  elements.

- `cmarkit` tool: install manpages and completions.

- Less eager escaping of `#` characters in CommonMark renderings.
  Thanks to Thomas Gazagnaire for the report (dune-universe/cmarkit#25).

- Less eager escaping of `.` and `)` characters in CommonMark rendering.
  Thanks to Ty Overby for the report (dune-universe/cmarkit#19).

- Fix incorrect parsing of code spans if they start with an escaped
  backtick (dune-universe/cmarkit#21).

- Fix incorrect escaping of backticks in CommonMark renderings (dune-universe/cmarkit#26).

- Fix incorrect escaping of tildes for CommonMark rendering interpreted
  with extensions (strikethrough becomes code fence).
  Thanks to Tianyi Song for the report (dune-universe/cmarkit#20).

- Fix `Cmarkit.Mapper`. Do not drop empty table cells.
  Thanks to Hannes Mehnert for the report (dune-universe/cmarkit#14).

- Fix out of bounds exception when lists are terminated by the end of file.
  Thanks to Ty Overby for the report (dune-universe/cmarkit#18).

- Fix invalid HTML markup generated for cancelled task items.
  Thanks to Sebastien Mondet for the report (dune-universe/cmarkit#15).

- Fix misspelling of `--leading_l` variable in `cmarkit html`'s
  CSS file.

- Updated data for Unicode 17.0.0.

- Require (depopt) `cmdliner` 2.0.0.
