### PR TITLE
Merge mirage-opam-overlays into this repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,25 @@ not attempt to replace it.
 
 It's meant to be used by the [`opam-monorepo`](https://github.com/tarides/opam-monorepo)
 tool to allow you to vendor your dependencies and build your entire project using
-`dune` only.
+`dune` only, specifically in the context of building Mirage unikernels.
+
+For that reason, all ports in this repo are required to be cross-compilable
+(previously, a separate
+[mirage-opam-overlays](https://github.com/dune-universe/mirage-opam-overlays)
+existed for that purpose, which is now merged into this one.
 
 All packages' versions in this repository are suffixed with a `+dune` to
 distinguish them from the upstream variants. That means that the
 `opam-overlays` port of package `abc` version `X.Y.Z` is available on this repo
 as `abc` version `X.Y.Z+dune`.
+
+> [!NOTE]
+> For historical reasons, this package previously had `+dune` (buildable with
+> dune) and `+dune+mirage` (cross-compilable) variants, existing in different
+> repositories (this one and mirage-opam-overlays).
+>
+> Both repositories are now merged, and for all versions `> 1.14`, the port is
+> required to be cross-compilable, without a need for the `+mirage` prefix.
 
 ## Port a new package/version to dune on `opam-overlays`
 

--- a/packages/zarith/zarith.1.12+dune+mirage/opam
+++ b/packages/zarith/zarith.1.12+dune+mirage/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "Xavier Leroy <xavier.leroy@inria.fr>"
+authors: [
+  "Antoine Miné"
+  "Xavier Leroy"
+  "Pascal Cuoq"
+]
+homepage: "https://github.com/mirage/Zarith"
+bug-reports: "https://github.com/mirage/Zarith/issues"
+dev-repo: "git+https://github.com/mirage/Zarith.git"
+build: [
+  ["dune" "build" "-p" "zarith" ]
+]
+depends: [
+  "ocaml"     {>= "4.04.0"}
+  "dune"
+  ("gmp" | "conf-gmp" )
+]
+synopsis:
+  "Implements arithmetic and logical operations over arbitrary-precision integers"
+description: """
+The Zarith library implements arithmetic and logical operations over
+arbitrary-precision integers. It uses GMP to efficiently implement
+arithmetic over big integers. Small integers are represented as Caml
+unboxed integers, for speed and space economy."""
+url {
+  src:
+    "https://github.com/mirage/Zarith/releases/download/release-1.12%2Bdune/zarith-release-1.12.dune.tbz"
+  checksum: [
+    "sha256=d3ba741bcba41e840c26565b7e71c35b1194165dafa0064b0d72b123ba068c41"
+    "sha512=1d50ced87218dd020d3f0a8f74595b7e677f47292634df734553ca2783fafdba3fb11c13c5849a674cb53e5aef9a4fff4201a47340315855f6d4493acf42d6c3"
+  ]
+}
+x-commit-hash: "ab890eed75dbefa6e49667619804a1a0b8d71069"
+tags: ["cross-compile"]

--- a/packages/zarith/zarith.1.12+dune+mirage1/opam
+++ b/packages/zarith/zarith.1.12+dune+mirage1/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "Xavier Leroy <xavier.leroy@inria.fr>"
+authors: [
+  "Antoine Miné"
+  "Xavier Leroy"
+  "Pascal Cuoq"
+]
+homepage: "https://github.com/ocaml/Zarith"
+bug-reports: "https://github.com/ocaml/Zarith/issues"
+dev-repo: "git+https://github.com/ocaml/Zarith.git"
+build: [
+  ["dune" "build" "-p" "zarith" ]
+]
+depends: [
+  "ocaml"     {>= "4.04.0"}
+  "dune"
+  ("gmp" | "conf-gmp" )
+]
+synopsis:
+  "Implements arithmetic and logical operations over arbitrary-precision integers"
+description: """
+The Zarith library implements arithmetic and logical operations over
+arbitrary-precision integers. It uses GMP to efficiently implement
+arithmetic over big integers. Small integers are represented as Caml
+unboxed integers, for speed and space economy."""
+url {
+  src:
+    "https://github.com/mirage/Zarith/releases/download/release-1.12+dune1/zarith-release-1.12+dune1.tbz"
+  checksum: [
+    "sha256=d12d2ca647b493cbd9ef942153208b7c651b3cdb45ab1cf04cff4ebf4bfa102e"
+    "sha512=49915e47f34b1b693dc176062f876c1a2c6e5310a2e100484e5cb09819eae9d05ff6228f92a37add80aa9d3243a179808ac4f2a412f9af2bf242fb288c31395a"
+  ]
+}
+tags: ["cross-compile"]
+x-commit-hash: "f9f300a562403a65d1d695cd756aa1ffa24d4364"

--- a/packages/zarith/zarith.1.13+dune+mirage/opam
+++ b/packages/zarith/zarith.1.13+dune+mirage/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "Xavier Leroy <xavier.leroy@inria.fr>"
+authors: [
+  "Antoine Miné"
+  "Xavier Leroy"
+  "Pascal Cuoq"
+]
+homepage: "https://github.com/mirage/Zarith"
+bug-reports: "https://github.com/mirage/Zarith/issues"
+dev-repo: "git+https://github.com/mirage/Zarith.git"
+license: "LGPL-2.0-only WITH OCaml-LGPL-linking-exception"
+build: [
+  ["dune" "build" "-p" "zarith" ]
+]
+depends: [
+  "ocaml"     {>= "4.04.0"}
+  "dune" {>= "2.8"}
+  ("gmp" | "conf-gmp" )
+]
+conflicts: [ "gmp" {< "6.2.1-5"} ]
+synopsis:
+  "Implements arithmetic and logical operations over arbitrary-precision integers"
+description: """
+The Zarith library implements arithmetic and logical operations over
+arbitrary-precision integers. It uses GMP to efficiently implement
+arithmetic over big integers. Small integers are represented as Caml
+unboxed integers, for speed and space economy."""
+tags: ["cross-compile"]
+url {
+  src:
+    "https://github.com/mirage/Zarith/releases/download/1.13%2Bdune%2Bmirage/zarith-1.13.dune.mirage.tbz"
+  checksum: [
+    "sha256=ed1926f678d1bacf66270d7b3f76587b1dc3ef63f12012e221dea5377c32219c"
+    "sha512=948d6ee41dca29be7a9912d3732b2ff9a039e4fc1b8a5679cab53e6e93228f9016b1802ef7dd210e713f975616eff48a692c5a17f29840e7675c576dfb4d7514"
+  ]
+}
+x-commit-hash: "9de5ec36fc0851f19985b235aa07d56661688155"

--- a/packages/zarith/zarith.1.14+dune+mirage/opam
+++ b/packages/zarith/zarith.1.14+dune+mirage/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "Xavier Leroy <xavier.leroy@inria.fr>"
+authors: [
+  "Antoine Miné"
+  "Xavier Leroy"
+  "Pascal Cuoq"
+]
+homepage: "https://github.com/mirage/Zarith"
+bug-reports: "https://github.com/mirage/Zarith/issues"
+dev-repo: "git+https://github.com/mirage/Zarith.git"
+license: "LGPL-2.0-only WITH OCaml-LGPL-linking-exception"
+build: [
+  ["dune" "build" "-p" "zarith" ]
+]
+depends: [
+  "ocaml"     {>= "4.07.0"}
+  "dune" {>= "2.8"}
+  ("gmp" | "conf-gmp" )
+]
+conflicts: [ "gmp" {< "6.2.1-5"} ]
+synopsis:
+  "Implements arithmetic and logical operations over arbitrary-precision integers"
+description: """
+The Zarith library implements arithmetic and logical operations over
+arbitrary-precision integers. It uses GMP to efficiently implement
+arithmetic over big integers. Small integers are represented as Caml
+unboxed integers, for speed and space economy."""
+tags: ["cross-compile"]
+url {
+  src:
+    "https://github.com/mirage/Zarith/releases/download/1.14%2Bdune%2Bmirage/zarith-1.14.dune.mirage.tbz"
+  checksum: [
+    "sha256=6e6c5c9555753a4bd7fed4693648808a5cea399f4999be5d567bb2acbb6d2d9d"
+    "sha512=89a63a869304941d31b80793545c860820d253fbe1da52246c4549e0b3702d5859290866396ef8cb87316f527e585d91376e748c59874ebd99f819419dd55ced"
+  ]
+}

--- a/packages/zarith/zarith.1.14+dune+mirage1/opam
+++ b/packages/zarith/zarith.1.14+dune+mirage1/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "Xavier Leroy <xavier.leroy@inria.fr>"
+authors: [
+  "Antoine Miné"
+  "Xavier Leroy"
+  "Pascal Cuoq"
+]
+homepage: "https://github.com/mirage/Zarith"
+bug-reports: "https://github.com/mirage/Zarith/issues"
+dev-repo: "git+https://github.com/mirage/Zarith.git"
+license: "LGPL-2.0-only WITH OCaml-LGPL-linking-exception"
+build: [
+  ["dune" "build" "-p" "zarith" ]
+]
+depends: [
+  "ocaml"     {>= "4.07.0"}
+  "dune" {>= "2.8"}
+  ("gmp" | "conf-gmp" )
+]
+conflicts: [ "gmp" {< "6.2.1-5"} ]
+synopsis:
+  "Implements arithmetic and logical operations over arbitrary-precision integers"
+description: """
+The Zarith library implements arithmetic and logical operations over
+arbitrary-precision integers. It uses GMP to efficiently implement
+arithmetic over big integers. Small integers are represented as Caml
+unboxed integers, for speed and space economy."""
+tags: ["cross-compile"]
+url {
+  src:
+    "https://github.com/mirage/Zarith/archive/refs/tags/1.14+dune+mirage1.tar.gz"
+  checksum: [
+    "sha256=915bd53ebb608729eb76b4e5bc0580090d8428fe919c9bf9a5dcd39f739b49f7"
+    "sha512=e7a6f27acfbedff9f3132de1306235143e266614793014c2e62a7dbb9e07673993bbb0a9375d3efb71228a2b7b7c12f4a6728b689b25df11cbcbc33d34422c76"
+  ]
+}

--- a/repo
+++ b/repo
@@ -1,2 +1,3 @@
 opam-version: "2.0"
 upstream: "https://github.com/mirage/mirage-dev/tree/master/"
+announce: [ "NOTE: mirage-opam-overlays has been merged to opam-overlays since July 2026. If you are using opam-monorepo in a context other than Mirage and your builds are now breaking because of 'zarith', please open an issue at https://github.com/dune-universe/opam-overlays. This warning message will be removed in October 2026." ]

--- a/test/opam-overlays/dune
+++ b/test/opam-overlays/dune
@@ -3,4 +3,6 @@
   (target packages)
   (action (bash "cp -r ../../packages packages")))
 
+(rule (copy ../../repo repo))
+
 (data_only_dirs packages)

--- a/test/opam-overlays/repo
+++ b/test/opam-overlays/repo
@@ -1,1 +1,0 @@
-opam-version: "2.0"


### PR DESCRIPTION
Bring cross-compilable ports of `zarith` into this repo, in order to deprecate `mirage-opam-overlays`.

Include a message that will be displayed when adding this repo, to ensure we are not breaking the workflow of non-mirage users, if any.

The goal is to make explicit that onwards, this repository requires all ports to be cross-compilable anyway, since Mirage is the main (if not sole) user of opam-overlays.